### PR TITLE
Make E-trade Gains And Losses import button reusable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,15 @@
   "rules": {
     "prefer-const": "error",
     "indent": ["error", 2],
+    "@stylistic/js/max-len": [
+      "error",
+      {
+        "code": 80,
+        "tabWidth": 2,
+        "ignoreComments": true,
+        "ignorePattern": "^import\\s.+\\sfrom\\s.+;$"
+      }
+    ],
     "@stylistic/js/quotes": ["error", "double"],
     "@stylistic/js/jsx-quotes": ["error", "prefer-double"],
     "@stylistic/js/semi": ["error", "always"],

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,4 @@
+{
+  "eslint.autoFixOnSave": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/app/guide/resident_fr/espp/sell_year/grant_fr/report_fr/page.tsx
+++ b/app/guide/resident_fr/espp/sell_year/grant_fr/report_fr/page.tsx
@@ -27,7 +27,7 @@ export default function Page() {
               Gains and Losses
             </Link>{" "}
             page after selecting your tax year and clicking "Download" and
-            "Download Collapsed" or "Download Expanded".
+            "Download Expanded".
           </p>
         </div>
       </Section>

--- a/app/guide/shared/EtradeGainAndLossesFileInput.tsx
+++ b/app/guide/shared/EtradeGainAndLossesFileInput.tsx
@@ -1,0 +1,44 @@
+import { FileInput } from "@/app/guide/shared/ui/FileInput";
+import { GainAndLossEvent } from "@/lib/etrade/etrade.types";
+import { parseEtradeGL } from "@/lib/etrade/parse-etrade-gl";
+import { sendErrorToast } from "./ui/Toast";
+
+export interface EtradeGainAndLossesFileInputProps {
+  /** Unique identifier for the input. Available for css selector as `#${id}` */
+  id?: string;
+  /** Label for the input */
+  label?: string;
+  /** Function called when data are read from the etrade export  */
+  setData: (data: GainAndLossEvent[]) => void;
+  /** Function called when an error occurs. */
+  handleError?: (error: string) => void;
+}
+
+export const EtradeGainAndLossesFileInput: React.FunctionComponent<
+  EtradeGainAndLossesFileInputProps
+> = ({
+  id = "import_etrade_g&l",
+  label = "Import from ETrade G&L",
+  setData,
+  handleError = sendErrorToast,
+}) => {
+  return (
+    <FileInput
+      accept=".xlsx"
+      id={id}
+      label={label}
+      onUpload={async (file) => {
+        if (!file) {
+          return handleError("couldn't import file");
+        }
+        try {
+          const data = await parseEtradeGL(file);
+          setData(data);
+        } catch (e) {
+          handleError(`Failed to import,
+                please verify you imported the correct file.`);
+        }
+      }}
+    />
+  );
+};

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,4 +1,5 @@
 import { ExchangeRate } from "@/hooks/use-fetch-exr";
+import { GainAndLossEvent } from "@/lib/etrade/etrade.types";
 
 export interface SaleEventData {
   quantity: number;
@@ -16,6 +17,18 @@ export const getDefaultData = (defaultDate: string): SaleEventData => ({
   dateSold: defaultDate,
   dateAcquired: defaultDate,
   adjustedCost: 0,
+  rateAcquired: { isFetching: true, rate: null, errorMessage: null },
+  rateSold: { isFetching: true, rate: null, errorMessage: null },
+});
+
+export const saleEventFromGainAndLossEvent = (
+  data: GainAndLossEvent,
+): SaleEventData => ({
+  quantity: data.quantity,
+  proceeds: data.proceeds,
+  dateSold: data.dateSold,
+  dateAcquired: data.dateAcquired,
+  adjustedCost: data.adjustedCost,
   rateAcquired: { isFetching: true, rate: null, errorMessage: null },
   rateSold: { isFetching: true, rate: null, errorMessage: null },
 });

--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -1,0 +1,29 @@
+export type PlanType = "ESPP" | "RS" | "SO";
+export type PlanQualification = "Qualified" | "Non-Qualified";
+
+/**
+ * Original format for the XLSX file rows in the Etrade Gain/Loss report.
+ */
+export interface GainAndLossEventXlsxRow {
+  "Plan Type": PlanType;
+  "Qty.": number;
+  "Date Acquired": string;
+  "Date Sold": string;
+  "Adjusted Cost Basis Per Share": number;
+  "Proceeds Per Share": number;
+  "Qualified Plan": PlanQualification;
+}
+
+/**
+ * Data format for a single sale event after parsing the Etrade Gain/Loss report.
+ */
+export interface GainAndLossEvent {
+  planType: PlanType;
+  quantity: number;
+  proceeds: number;
+  adjustedCost: number;
+  dateAcquired: string;
+  dateSold: string;
+  isPlanUsQualified: boolean;
+  isPlanFrQualified: boolean;
+}

--- a/lib/etrade/parse-etrade-gl.ts
+++ b/lib/etrade/parse-etrade-gl.ts
@@ -1,0 +1,72 @@
+import {
+  GainAndLossEvent,
+  GainAndLossEventXlsxRow,
+  PlanType,
+} from "./etrade.types";
+import { getDateString } from "@/lib/date";
+import XLSX from "xlsx";
+
+const toDateString = (rawDate: string) =>
+  getDateString(new Date(Date.parse(rawDate)));
+
+export const parseEtradeGL = async (
+  file: File,
+): Promise<GainAndLossEvent[]> => {
+  const data: GainAndLossEvent[] = [];
+  const fileAsArrayBuffer = await file.arrayBuffer();
+  const workbook = XLSX.read(fileAsArrayBuffer);
+  const worksheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rawData = XLSX.utils.sheet_to_json(worksheet, { header: 2 });
+  // First row is summary
+  for (let rowIdx = 1; rowIdx < rawData.length; rowIdx++) {
+    const row = rawData[rowIdx] as GainAndLossEventXlsxRow;
+    try {
+      data.push({
+        planType: row["Plan Type"],
+        quantity: row["Qty."],
+        proceeds: row["Proceeds Per Share"],
+        adjustedCost: row["Adjusted Cost Basis Per Share"],
+        dateAcquired: toDateString(row["Date Acquired"]),
+        dateSold: toDateString(row["Date Sold"]),
+        isPlanUsQualified: row["Qualified Plan"] === "Qualified",
+        // For now consider that non-US qualified plan is FR
+        // qualified.
+        isPlanFrQualified: row["Qualified Plan"] !== "Qualified",
+      });
+    } catch {
+      return Promise.reject(`format of file '${file.name}' is not supported`);
+    }
+  }
+  return Promise.resolve(data);
+};
+
+/**
+ * Create a filter function from provided filters.
+ *
+ * To get every FR qualified stock options events from the Etrade Gain/Loss
+ * report:
+ *
+ * ```ts
+ * const isFrQualifiedStock = createEtradeGLFilter({
+ *   planType: "SO",
+ *   isPlanFrQualified: true
+ * });
+ *
+ * const frQualifiedStockEvents = gainAndLossEvents.filter(isFrQualifiedStock);
+ * ```
+ */
+export const createEtradeGLFilter = (filter: {
+  planType?: PlanType;
+  isPlanUsQualified?: boolean;
+  isPlanFrQualified?: boolean;
+}) => {
+  const filterKeys = Object.keys(filter) as (keyof typeof filter)[];
+  return function filterEtradeGLFilter(event: GainAndLossEvent): boolean {
+    return filterKeys.every((key) => {
+      if (filter[key] === undefined) {
+        return true;
+      }
+      return event[key] === filter[key];
+    });
+  };
+};


### PR DESCRIPTION
This PR makes the etrade import logic reusable in other places:

- not limited to ESPP
- infers grant type (Qualified FR or Qualified US) from "expanded" Gains and losses file


