### PR TITLE
Fixes date parsing with timezone

### DIFF
--- a/lib/date.test.ts
+++ b/lib/date.test.ts
@@ -1,0 +1,28 @@
+import { getDateString, parseEtradeDate } from "./date";
+
+describe("date", () => {
+  describe("getDateString", () => {
+    it("should return date in string format", () => {
+      const date = new Date(Date.UTC(2021, 8 /* month starts at 0... */, 1));
+      expect(getDateString(date)).toEqual("2021-09-01");
+    });
+  });
+
+  describe("parseEtradeDate", () => {
+    it("should return date in string format", () => {
+      const rawDate = "09/01/2021";
+      expect(parseEtradeDate(rawDate)).toEqual(
+        new Date(Date.UTC(2021, 8 /* month starts at 0... */, 1)),
+      );
+    });
+
+    it("should return a date that can be parsed back", () => {
+      const rawDate = "09/01/2021";
+      const parsed = parseEtradeDate(rawDate);
+
+      expect(new Date(parsed).toISOString()).toEqual(
+        "2021-09-01T00:00:00.000Z",
+      );
+    });
+  });
+});

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,2 +1,7 @@
 export const getDateString = (date: Date) =>
   date.toISOString().substring(0, 10);
+
+export const parseEtradeDate = (rawDate: string) => {
+  const [month, day, year] = rawDate.split("/").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+};

--- a/lib/etrade/parse-etrade-gl.ts
+++ b/lib/etrade/parse-etrade-gl.ts
@@ -3,11 +3,11 @@ import {
   GainAndLossEventXlsxRow,
   PlanType,
 } from "./etrade.types";
-import { getDateString } from "@/lib/date";
+import { getDateString, parseEtradeDate } from "@/lib/date";
 import XLSX from "xlsx";
 
 const toDateString = (rawDate: string) =>
-  getDateString(new Date(Date.parse(rawDate)));
+  getDateString(parseEtradeDate(rawDate));
 
 export const parseEtradeGL = async (
   file: File,


### PR DESCRIPTION
There were an issue due to timezone in europe.

Etrade provides dates in format `MM/DD/YYYY`, for instance `11/20/2023`.

`parseEtradeDate` returns `2023/11/20T00:00:000.00Z`, which in France is the same as `2023/11/19T22:00:000.00UTC`, and in the NYC is the same as `2023/11/20T04:00:000.00UTC`.

When passed to `getDateString` which performs a `date.toISOString()`, in France returned date was **the day before**.