### PR TITLE
Add some fields to etrade Gains And Losses import

### DIFF
--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -6,10 +6,12 @@ export type PlanQualification = "Qualified" | "Non-Qualified";
  */
 export interface GainAndLossEventXlsxRow {
   "Plan Type": PlanType;
+  Symbol: string;
   "Qty.": number;
   "Date Acquired": string;
   "Date Sold": string;
   "Adjusted Cost Basis Per Share": number;
+  "Acquisition Cost Per Share": number;
   "Proceeds Per Share": number;
   "Qualified Plan": PlanQualification;
 }
@@ -19,10 +21,27 @@ export interface GainAndLossEventXlsxRow {
  */
 export interface GainAndLossEvent {
   planType: PlanType;
+  symbol: string;
   quantity: number;
+  /** Proceeds per share in USD: sell price. */
   proceeds: number;
+  /**
+   * Value when the share has been acquired for US taxes.
+   * Usually SYMBOL price at closing on time of acquisition.
+   *
+   * For French taxes, it should be the opening price of the day.
+   * See https://bofip.impots.gouv.fr/bofip/5654-PGP.html/identifiant%3DBOI-RSA-ES-20-20-20-20170724#:~:text=120,au%20m%C3%AAme%20jour.
+   */
   adjustedCost: number;
+  /**
+   * Acquisition cost per share in USD.
+   * The price, in USD at which the share was acquired.
+   *
+   * This is 0 for RSUs, adjustedCost for ESPP and the grant price for SO.
+   */
+  acquisitionCost: number;
   dateAcquired: string;
   dateSold: string;
+  /** What kind of qualified plan is it? */
   qualifiedIn: "fr" | "us";
 }

--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -26,7 +26,7 @@ export interface GainAndLossEvent {
   /** Proceeds per share in USD: sell price. */
   proceeds: number;
   /**
-   * Value when the share has been acquired for US taxes.
+   * Value when the share was acquired for US taxes.
    * Usually SYMBOL price at closing on time of acquisition.
    *
    * For French taxes, it should be the opening price of the day.

--- a/lib/etrade/filters.ts
+++ b/lib/etrade/filters.ts
@@ -1,0 +1,23 @@
+import { createEtradeGLFilter } from "@/lib/etrade/parse-etrade-gl";
+
+export const isFrQualifiedSo = createEtradeGLFilter({
+  planType: "SO",
+  qualifiedIn: "fr",
+});
+export const isUsQualifiedSo = createEtradeGLFilter({
+  planType: "SO",
+  qualifiedIn: "us",
+});
+
+export const isEspp = createEtradeGLFilter({
+  planType: "ESPP",
+});
+
+export const isFrQualifiedRsu = createEtradeGLFilter({
+  planType: "RS",
+  qualifiedIn: "fr",
+});
+export const isUsQualifiedRsu = createEtradeGLFilter({
+  planType: "RS",
+  qualifiedIn: "us",
+});

--- a/lib/etrade/parse-etrade-gl.ts
+++ b/lib/etrade/parse-etrade-gl.ts
@@ -23,12 +23,14 @@ export const parseEtradeGL = async (
     try {
       data.push({
         planType: row["Plan Type"],
+        symbol: row["Symbol"],
         quantity: row["Qty."],
         proceeds: row["Proceeds Per Share"],
         // FIXME: Adjusted cost from ETrade's G&L is the close price on day acquired,
         // France expects the opening price on day acquired.
         // See https://bofip.impots.gouv.fr/bofip/5654-PGP.html/identifiant%3DBOI-RSA-ES-20-20-20-20170724#:~:text=a.%20Actions%20cot%C3%A9es-,120,-La%20valeur%20%C3%A0
         adjustedCost: row["Adjusted Cost Basis Per Share"],
+        acquisitionCost: row["Acquisition Cost Per Share"],
         dateAcquired: toDateString(row["Date Acquired"]),
         dateSold: toDateString(row["Date Sold"]),
         // For now consider that a non-US qualified plan is FR qualified.
@@ -50,7 +52,7 @@ export const parseEtradeGL = async (
  * ```ts
  * const isFrQualifiedStock = createEtradeGLFilter({
  *   planType: "SO",
- *   isPlanFrQualified: true
+ *   qualifiedIn: "fr",
  * });
  *
  * const frQualifiedStockEvents = gainAndLossEvents.filter(isFrQualifiedStock);
@@ -58,7 +60,7 @@ export const parseEtradeGL = async (
  */
 export const createEtradeGLFilter = (filter: {
   planType?: PlanType;
-  qualifiedIn: "fr" | "us";
+  qualifiedIn?: "fr" | "us";
 }) => {
   const filterKeys = Object.keys(filter) as (keyof typeof filter)[];
   return function filterEtradeGLFilter(event: GainAndLossEvent): boolean {


### PR DESCRIPTION
- Add some filters for gains and losses.
- Add symbol to be able to fetch historical prices for french taxes
- Add acquisition cost to compute acquisition gains for stock options