### PR TITLE
Add rate date logic to etrade import

### DIFF
--- a/app/guide/shared/Calculator/Calculator.tsx
+++ b/app/guide/shared/Calculator/Calculator.tsx
@@ -23,20 +23,15 @@ import {
   saleEventFromGainAndLossEvent,
 } from "@/lib/data";
 import { createEtradeGLFilter } from "@/lib/etrade/parse-etrade-gl";
-import { getDateString } from "@/lib/date";
+import {
+  getDateString,
+  isWeekendDay,
+  getNumDaysSinceLastFriday,
+} from "@/lib/date";
 import { calcTotals as calcTotals } from "@/lib/calc-totals";
 import { Currency } from "@/app/guide/shared/ui/Currency";
 import { EtradeGainAndLossesFileInput } from "@/app/guide/shared/EtradeGainAndLossesFileInput";
 import { PlanType } from "@/lib/etrade/etrade.types";
-
-// On Saturday:
-// date.getDay() = 6 => date.getDay() / 6 = 1 => numDaysSinceLastFriday = 1
-// On Sunday:
-// date.getDay() = 0 => date.getDay() / 6 = 0 => numDaysSinceLastFriday = 2
-const getNumDaysSinceLastFriday = (date: Date) =>
-  2 - Math.floor(date.getDay() / 6);
-
-const isWeekendDay = (date: Date) => date.getDay() % 6 === 0;
 
 /**
  * Compute value of the abatement for income taxes based on the income value.

--- a/app/guide/shared/Calculator/_SaleEvent.tsx
+++ b/app/guide/shared/Calculator/_SaleEvent.tsx
@@ -1,4 +1,4 @@
-import { NumberField, DateField } from "@/app/guide/shared/ui/Field";
+import { NumberField, DateField, RateField } from "@/app/guide/shared/ui/Field";
 import { useExchangeRates } from "@/hooks/use-fetch-exr";
 import { useEffect, useMemo } from "react";
 import { getAdjustedGainLoss } from "@/lib/get-adjusted-gain-loss";
@@ -115,7 +115,7 @@ export const SaleEvent = ({
             onChange={(value) => setDateAcquired(value)}
             placeholder="Select date"
           />
-          <NumberField
+          <RateField
             value={dateAcquiredExr.rate}
             label="$ / €"
             isReadOnly
@@ -168,7 +168,7 @@ export const SaleEvent = ({
             onChange={(value) => setDateSold(value)}
             placeholder="Select date"
           />
-          <NumberField
+          <RateField
             value={dateSoldExr.rate}
             label="$ / €"
             isReadOnly

--- a/app/guide/shared/ui/Field.tsx
+++ b/app/guide/shared/ui/Field.tsx
@@ -136,6 +136,34 @@ const DateInput = ({
   />
 );
 
+interface RateInputProps extends BaseInputProps<number> {}
+
+const RateInput = ({
+  isLoading,
+  isReadOnly,
+  isRequired,
+  value,
+  onChange,
+  min,
+  max,
+  placeholder,
+  validationError,
+}: NumberInputProps) => (
+  <Input
+    required={isRequired}
+    readOnly={isReadOnly}
+    type="number"
+    placeholder={placeholder}
+    value={value}
+    onChange={(event) => onChange?.(event.target.valueAsNumber)}
+    min={min}
+    max={max}
+    step={1 / 10 ** 4}
+    validationError={validationError}
+    isLoading={isLoading}
+  />
+);
+
 type NumberFieldProps = NumberInputProps & { label: string };
 
 export const NumberField = ({ label, ...inputProps }: NumberFieldProps) => (
@@ -151,5 +179,14 @@ export const DateField = ({ label, ...inputProps }: DateFieldProps) => (
   <div>
     <Label>{label}</Label>
     <DateInput {...inputProps} />
+  </div>
+);
+
+type RateFieldProps = RateInputProps & { label: string };
+
+export const RateField = ({ label, ...inputProps }: RateFieldProps) => (
+  <div>
+    <Label>{label}</Label>
+    <RateInput {...inputProps} />
   </div>
 );

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -5,3 +5,12 @@ export const parseEtradeDate = (rawDate: string) => {
   const [month, day, year] = rawDate.split("/").map(Number);
   return new Date(Date.UTC(year, month - 1, day));
 };
+
+// On Saturday:
+// date.getDay() = 6 => date.getDay() / 6 = 1 => numDaysSinceLastFriday = 1
+// On Sunday:
+// date.getDay() = 0 => date.getDay() / 6 = 0 => numDaysSinceLastFriday = 2
+export const getNumDaysSinceLastFriday = (date: Date) =>
+  2 - Math.floor(date.getDay() / 6);
+
+export const isWeekendDay = (date: Date) => date.getDay() % 6 === 0;


### PR DESCRIPTION
Sometimes, acquisition date is on a weekend date and since there are no exchange rates on weekends, we get the last available rate (last friday).

This PR also adds a RateField UI component in order to display rates with all their decimals.
This ways, a user can better understand the (small) differences in taxable income when navigating between (close) dates.