### PR TITLE
Add FrTaxableEvent

### DIFF
--- a/components/TaxableEventFr.tsx
+++ b/components/TaxableEventFr.tsx
@@ -1,0 +1,128 @@
+import { TaxableEventFr as TaxableEventFrProps } from "@/lib/taxes/taxable-event-fr";
+import { match } from "ts-pattern";
+import { Drawer } from "./ui/Drawer";
+import { Currency } from "@/app/guide/shared/ui/Currency";
+import { PriceInEuro } from "./ui/PriceInEuro";
+import { formatDateFr } from "@/lib/date";
+
+export const TaxableEventFr: React.FunctionComponent<{
+  event: TaxableEventFrProps;
+  showAcquisitionGains?: boolean;
+  showCapitalGains?: boolean;
+  forceOpen?: boolean;
+}> = ({
+  event,
+  showCapitalGains = false,
+  showAcquisitionGains = false,
+  forceOpen,
+}) => {
+  const asset = match(event.planType)
+    .with("ESPP", () => "ESPP")
+    .with("RS", () => "RSU")
+    .with("SO", () => "Stock options")
+    .exhaustive();
+
+  const trigger = match(event.type)
+    .with("vesting", () => "vested")
+    .with("sell", () => "sold")
+    .with("exercise", () => "exercised")
+    .exhaustive();
+
+  return (
+    <Drawer
+      forceOpen={forceOpen}
+      title={
+        <div className="flex items-baseline justify-start gap-2">
+          <h2 className="font-bold text-lg">
+            On {formatDateFr(event.date)} {trigger} {event.quantity} {asset}
+          </h2>
+
+          <dl className="flex items-baseline justify-start gap-2">
+            {showCapitalGains && (
+              <>
+                <dt className="font-bold">Capital gain</dt>
+                <dd>
+                  <Currency value={event.capitalGain.total} unit="eur" />
+                </dd>
+              </>
+            )}
+            {showAcquisitionGains && (
+              <>
+                <dt className="font-bold">Acquisition gain</dt>
+                <dd>
+                  <Currency value={event.acquisitionGain.total} unit="eur" />
+                </dd>
+              </>
+            )}
+          </dl>
+        </div>
+      }
+    >
+      <TaxableEventFrLine title="Acquisition cost">
+        <PriceInEuro
+          eur={event.acquisition.costEur}
+          usd={event.acquisition.costUsd}
+          rate={event.acquisition.rate}
+          date={event.acquisition.date}
+        />{" "}
+        per share.
+      </TaxableEventFrLine>
+      <TaxableEventFrLine title="Acquisition value">
+        <PriceInEuro
+          eur={event.acquisition.valueEur}
+          usd={event.acquisition.valueUsd}
+          rate={event.acquisition.rate}
+          date={event.acquisition.date}
+        />{" "}
+        per share ({event.acquisition.description})
+      </TaxableEventFrLine>
+      {event.sell && (
+        <TaxableEventFrLine title="Sell price">
+          <PriceInEuro
+            eur={event.sell.eur}
+            usd={event.sell.usd}
+            rate={event.sell.rate}
+            date={event.sell.date}
+          />{" "}
+          per share on {formatDateFr(event.sell.date)}
+        </TaxableEventFrLine>
+      )}
+      <TaxableEventFrLine title={`${event.symbol} price:`}>
+        <PriceInEuro
+          eur={event.acquisition.symbolPriceEur}
+          usd={event.acquisition.symbolPrice}
+          rate={event.acquisition.rate}
+          date={event.acquisition.date}
+        />{" "}
+        at opening on acquisition day.
+      </TaxableEventFrLine>
+      {(showAcquisitionGains || showCapitalGains) && (
+        <hr className="h-px my-1 mx-auto w-1/3 border-0 bg-gray-400" />
+      )}
+      {showAcquisitionGains && (
+        <TaxableEventFrLine title="Acquisition gain">
+          <Currency value={event.acquisitionGain.perShare} unit="eur" /> per
+          share.
+        </TaxableEventFrLine>
+      )}
+      {showCapitalGains && (
+        <TaxableEventFrLine title="Capital gain">
+          <Currency value={event.capitalGain.perShare} unit="eur" /> per share.
+        </TaxableEventFrLine>
+      )}
+    </Drawer>
+  );
+};
+interface TaxableEventFrLineProps {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}
+const TaxableEventFrLine: React.FunctionComponent<TaxableEventFrLineProps> = ({
+  title,
+  children,
+}) => (
+  <div className="flex items-start justify-stretch">
+    <h4 className="w-1/3">{title}</h4>
+    <div className="grow">{children}</div>
+  </div>
+);

--- a/components/ui/Drawer.tsx
+++ b/components/ui/Drawer.tsx
@@ -3,8 +3,11 @@ import { useState } from "react";
 export const Drawer: React.FunctionComponent<{
   title: React.ReactNode;
   children: React.ReactNode;
-}> = ({ title, children }) => {
-  const [isOpen, setIsOpen] = useState(false);
+  isDefaultOpen?: boolean;
+  forceOpen?: boolean;
+}> = ({ title, children, isDefaultOpen = false, forceOpen = false }) => {
+  const [isOpen, setIsOpen] = useState(isDefaultOpen);
+  const showBody = isOpen || forceOpen;
   return (
     <div>
       <div
@@ -12,9 +15,9 @@ export const Drawer: React.FunctionComponent<{
         onClick={() => setIsOpen(!isOpen)}
       >
         <div>{title}</div>
-        <span>{isOpen ? "▲" : "▼"}</span>
+        <span>{showBody ? "▲" : "▼"}</span>
       </div>
-      {isOpen && <div>{children}</div>}
+      {showBody && <div>{children}</div>}
     </div>
   );
 };

--- a/lib/date.test.ts
+++ b/lib/date.test.ts
@@ -1,4 +1,4 @@
-import { getDateString, parseEtradeDate } from "./date";
+import { formatDateFr, getDateString, parseEtradeDate } from "./date";
 
 describe("date", () => {
   describe("getDateString", () => {
@@ -23,6 +23,26 @@ describe("date", () => {
       expect(new Date(parsed).toISOString()).toEqual(
         "2021-09-01T00:00:00.000Z",
       );
+    });
+  });
+
+  describe("formatDateFr", () => {
+    it("should return a French date", () => {
+      expect(formatDateFr("2021-09-01")).toEqual("1 sep 2021");
+    });
+
+    it("should throw if date format is not valid", () => {
+      expect(() => formatDateFr("2021-09-01-01")).toThrow(
+        "Invalid date format",
+      );
+    });
+
+    it("should throw if month is invalid", () => {
+      expect(() => formatDateFr("2021-13-01")).toThrow("Invalid month");
+    });
+
+    it("should throw if day is invalid", () => {
+      expect(() => formatDateFr("2021-09-32")).toThrow("Invalid day");
     });
   });
 });

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -20,10 +20,21 @@ const months = [
   "nov",
   "dec",
 ];
+const pattern = /^\d{4}-\d{2}-\d{2}$/;
 /**
- * Format a date to a French date.
+ * Format a date of format `YYYY-MM-DD` to a French date string `DD month YYYY`.
  */
 export const formatDateFr = (/** format YYYY-MM-DD */ date: string) => {
+  if (!pattern.test(date)) {
+    throw new Error("Invalid date format");
+  }
+
   const [year, monthNumber, day] = date.split("-").map(Number);
-  return `${day} ${months[monthNumber]} ${year}`;
+  if (monthNumber < 1 || monthNumber > 12) {
+    throw new Error("Invalid month");
+  }
+  if (day < 1 || day > 31) {
+    throw new Error("Invalid day");
+  }
+  return `${day} ${months[monthNumber - 1]} ${year}`;
 };

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -5,3 +5,25 @@ export const parseEtradeDate = (rawDate: string) => {
   const [month, day, year] = rawDate.split("/").map(Number);
   return new Date(Date.UTC(year, month - 1, day));
 };
+
+const months = [
+  "jan",
+  "feb",
+  "mar",
+  "apr",
+  "may",
+  "jun",
+  "jul",
+  "aug",
+  "sep",
+  "oct",
+  "nov",
+  "dec",
+];
+/**
+ * Format a date to a French date.
+ */
+export const formatDateFr = (/** format YYYY-MM-DD */ date: string) => {
+  const [year, monthNumber, day] = date.split("-").map(Number);
+  return `${day} ${months[monthNumber]} ${year}`;
+};

--- a/lib/taxes/taxable-event-fr.ts
+++ b/lib/taxes/taxable-event-fr.ts
@@ -1,0 +1,61 @@
+export interface TaxableEventFr {
+  /** Symbol of the stock */
+  symbol: string;
+  planType: "ESPP" | "RS" | "SO";
+  /** What kind of qualified plan is it? */
+  qualifiedIn: "fr" | "us";
+  /** Taxable event type */
+  type: "vesting" | "sell" | "exercise";
+  /**
+   * Date of the taxable event.
+   * In format YYYY-MM-DD
+   */
+  date: string;
+  /** Number of shares */
+  quantity: number;
+  /**
+   * Sell information (per share).
+   * If the taxable event is about a non qualified vesting, this field is null.
+   */
+  sell: { usd: number; rate: number; eur: number; date: string } | null;
+  /** Acquisition information (per share) */
+  acquisition: {
+    /** Value of the share at acquistion in USD */
+    valueUsd: number;
+    /** Value of the share at acquistion in EUR */
+    valueEur: number;
+    /** Acquisition cost in USD */
+    costUsd: number;
+    /** Acquisition cost in EUR */
+    costEur: number;
+    /** Symbol price at opening price on time of exercise. */
+    symbolPrice: number;
+    /** Symbol price at opening price on time of exercise (in EUR). */
+    symbolPriceEur: number;
+    /** USD rate at time of acquisition */
+    rate: number;
+    /**
+     * Acquisition date
+     * In format YYYY-MM-DD
+     */
+    date: string;
+    /**
+     * Describe how the acquisition cost was calculated.
+     * Examples:
+     * - DDOG price at opening price on time of exercise.
+     * - DDOG price at opening price on time of vesting.
+     * - Sell price as the plan is qualified and the sale is at loss.
+     * - Sell price as this is a sell to cover.
+     * - DDOG price at opening price on time of vesting since the plan is not qualified.
+     * - DDOG price at opening price on time of exercise since the plan is not qualified.
+     */
+    description: string;
+  };
+  /** Computed capital gain for this taxable event */
+  capitalGain: { perShare: number; total: number };
+  /** Computed acquisition gain for this taxable event */
+  acquisitionGain: {
+    perShare: number;
+    total: number;
+  };
+}


### PR DESCRIPTION
This data model is used to convey everything that is used by French taxes to represent an event that should be declared to tax administration.

- Grant price of options
- acquisition value
- sell price

The associated component displays the following details:

<img width="863" alt="image" src="https://github.com/hinosxz/tax-helper/assets/245501/bb475da4-3a6e-4798-9a24-f3e87859c145">

A tax rule (Followup PR) will be responsible for:

- assigning acquisition value depending on the plan
- affect gains to related box in the tax form.