### PR TITLE
Add rules for french taxes

### DIFF
--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -45,3 +45,11 @@ export interface GainAndLossEvent {
   /** What kind of qualified plan is it? */
   qualifiedIn: "fr" | "us";
 }
+
+export interface BenefitHistoryEvent {
+  planType: PlanType;
+  dateVested: string;
+  quantity: number;
+  /** What kind of qualified plan is it? */
+  qualified: "FR" | "US";
+}

--- a/lib/etrade/parse-etrade-benefits.ts
+++ b/lib/etrade/parse-etrade-benefits.ts
@@ -1,0 +1,10 @@
+import { BenefitHistoryEvent } from "./etrade.types";
+
+export const parseEtradeBenefits = (
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  file: File,
+): Promise<BenefitHistoryEvent[]> => {
+  // Parsing of benefits is a level higher than parsing of gains and losses.
+  // let's keep it for later.
+  throw new Error("Not implemented");
+};

--- a/lib/format-number.test.ts
+++ b/lib/format-number.test.ts
@@ -1,4 +1,4 @@
-import { floorNumber, formatNumber } from "./format-number";
+import { floorNumber, ceilNumber, formatNumber } from "./format-number";
 
 describe("formatNumber", () => {
   it("should add 2 decimal places", () => {
@@ -16,10 +16,28 @@ describe("floorNumber", () => {
   it("should floor a number with 2 decimal places", () => {
     expect(floorNumber(1.234)).toBe(1.23);
   });
+  it("should work on number with 3 decimal places", () => {
+    expect(floorNumber(1.2342, 3)).toBe(1.234);
+  });
   it("should floor a number with 3 decimal places", () => {
-    expect(floorNumber(1.234, 3)).toBe(1.234);
+    expect(floorNumber(1.2347, 3)).toBe(1.234);
   });
   it("should floor a number with no decimals", () => {
     expect(floorNumber(1, 2)).toBe(1);
+  });
+});
+
+describe("ceilNumber", () => {
+  it("should ceil a number with 2 decimal places", () => {
+    expect(ceilNumber(1.234)).toBe(1.24);
+  });
+  it("should work on number with 3 decimal places", () => {
+    expect(ceilNumber(1.2342, 3)).toBe(1.235);
+  });
+  it("should ceil a number with 3 decimal places", () => {
+    expect(ceilNumber(1.2347, 3)).toBe(1.235);
+  });
+  it("should ceil a number with no decimals", () => {
+    expect(ceilNumber(1, 2)).toBe(1);
   });
 });

--- a/lib/format-number.ts
+++ b/lib/format-number.ts
@@ -24,3 +24,17 @@ export const floorNumber = (value: number, digits: number = 2): number => {
   const factor = Math.pow(10, digits);
   return Math.floor(value * factor) / factor;
 };
+
+/**
+ * Ceils a number with `digits` digits.
+ *
+ * ```
+ * ceilNumber(1.234) // 1.24
+ * ceilNumber(1.234, 3) // 1.234
+ * ceilNumber(1, 2) // 1
+ * ```
+ */
+export const ceilNumber = (value: number, digits: number = 2): number => {
+  const factor = Math.pow(10, digits);
+  return Math.ceil(value * factor) / factor;
+};

--- a/lib/taxes/taxes-rules-fr.test.ts
+++ b/lib/taxes/taxes-rules-fr.test.ts
@@ -1,0 +1,619 @@
+import { GainAndLossEvent } from "@/lib/etrade/etrade.types";
+import {
+  GainAndLossEventWithRates,
+  enrichEtradeGlFrFr,
+  getEmptyTaxes,
+  getFrTaxesForEspp,
+  getFrTaxesForFrQualifiedRsu,
+  getFrTaxesForFrQualifiedSo,
+  getFrTaxesForNonFrQualifiedRsu,
+  getFrTaxesForNonFrQualifiedSo,
+} from "./taxes-rules-fr";
+import { SymbolDailyResponse } from "@/lib/symbol-daily.types";
+
+describe("enrichEtradeGlFrFr", () => {
+  it("should work", () => {
+    const gainsAndLosses: GainAndLossEvent[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        acquisitionCost: 78,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+      },
+    ];
+    const rates = {
+      "2022-03-03": 1.12,
+      "2022-09-09": 1.13,
+    };
+    const ddogPrices: SymbolDailyResponse = {
+      "2022-03-03": { opening: 100, closing: 110 },
+      "2022-09-09": { opening: 110, closing: 120 },
+    };
+    expect(enrichEtradeGlFrFr(gainsAndLosses, { rates, ddogPrices })).toEqual([
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        acquisitionCost: 78,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ]);
+  });
+});
+
+describe("getFrTaxesForFrQualifiedSo", () => {
+  it("same day sell", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when daily value is 100$
+        adjustedCost: 80,
+        acquisitionCost: 20,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-03",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.12,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedSo(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+    // No capital gain
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+
+    // Acquisition gain
+    // sellPrice = 110 / 1.12 = 98.2142857143
+    // cost = 20 / 1.12 = 17.8571428571
+    // gain per share = 98.2142857143 - 17.8571428571 = 80.3571428571
+    expect(taxes["1TT"]).toEqual(803.57143);
+  });
+
+  it("sell with losses", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 90, // Sold at 90$ when acquired at 100$
+        adjustedCost: 80,
+        acquisitionCost: 20,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedSo(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+    // No capital gain
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+
+    // Acquisition gain
+    // sellPrice = 90 / 1.13 = 79.6460176991
+    // cost = 20 / 1.12 = 17.8571428571
+    // gain per share = 79.6460176991 - 17.8571428571 = 61.7888748419
+    expect(taxes["1TT"]).toEqual(617.88875);
+  });
+
+  it("sell with gains", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when acquired at 100$
+        adjustedCost: 80,
+        acquisitionCost: 20,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedSo(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+
+    // cost = 20 / 1.12 = 17.8571428571
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 110 / 1.13 = 97.3451327434
+    // capital gain = 97.3451327434 - 89.2857142857 = 8.0594184577
+    // acquisition gain = 89.2857142857 - 17.8571428571 = 71.4285714286
+
+    // Acquisition gain
+    expect(taxes["1TT"]).toEqual(714.28572);
+
+    // Capital gain
+    expect(taxes["3VG"].toFixed(6)).toEqual("80.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (Stock Options)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("97.345132");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("973.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("973.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("80.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+  });
+});
+
+describe("getFrTaxesForFrQualifiedRsu()", () => {
+  it("same day sell", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when daily value is 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-03",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.12,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedRsu(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+    // No capital gain
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+
+    // Acquisition gain
+    // sellPrice = 110 / 1.12 = 98.2142857143
+    // discount = 98.2142857143 / 2 = 49.1071428571
+    expect(taxes["1TZ"]).toEqual(491.071425);
+    expect(taxes["1TT"]).toEqual(0);
+    expect(taxes["1WZ"]).toEqual(491.071425);
+  });
+
+  it("sell with losses", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 90, // Sold at 90$ when acquired at 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedRsu(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+    // No capital gain
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+    // Acquisition gain
+    // sellPrice = 90 / 1.13 = 79.6460176991
+    // discount = 79.6460176991 / 2 = 39.8230088495
+    expect(taxes["1TZ"]).toEqual(398.230085);
+    expect(taxes["1TT"]).toEqual(0);
+    expect(taxes["1WZ"]).toEqual(398.230085);
+  });
+
+  it("sell with gains", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when acquired at 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedRsu(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 110 / 1.13 = 97.3451327434
+    // capital gain = 97.3451327434 - 89.2857142857 = 8.0594184577
+    // acquisition gain = 89.2857142857 - 0 = 89.2857142857
+    // discount = 89.2857142857 / 2 = 44.6428571429
+    // Acquisition gain
+    expect(taxes["1TZ"]).toEqual(446.42857);
+    expect(taxes["1TT"]).toEqual(0);
+    expect(taxes["1WZ"]).toEqual(446.42857);
+
+    // Capital gain
+    expect(taxes["3VG"].toFixed(6)).toEqual("80.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (RSU)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("97.345132");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("973.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("973.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("80.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+  });
+});
+
+describe("getFrTaxesForEspp", () => {
+  it("capital loss", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "ESPP",
+        quantity: 10,
+        proceeds: 90, // Sold at 90$ when acquired at 100$
+        adjustedCost: 100,
+        acquisitionCost: 80,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForEspp({ gainsAndLosses }, getEmptyTaxes());
+    // Capital loss
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 90 / 1.13 = 79.6460176991
+    // capital loss = 79.6460176991 - 89.2857142857 = -9.6396965866
+    expect(taxes["3VG"].toFixed(6)).toEqual("-97.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (ESPP)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("79.646017");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("796.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("796.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("-97.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+    // Acquisition gain
+    expect(taxes["1AJ"]).toEqual(0);
+    expect(taxes["1TZ"]).toEqual(0);
+    expect(taxes["1TT"]).toEqual(0);
+    expect(taxes["1WZ"]).toEqual(0);
+  });
+  it("capital gain", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "ESPP",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when acquired at 100$
+        adjustedCost: 100,
+        acquisitionCost: 80,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+
+    const taxes = getFrTaxesForEspp({ gainsAndLosses }, getEmptyTaxes());
+    // Capital gain
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 110 / 1.13 = 97.3451327434
+    // capital gain = 97.3451327434 - 89.2857142857 = 8.0594184577
+    expect(taxes["3VG"].toFixed(6)).toEqual("80.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (ESPP)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("97.345132");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("973.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("973.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("80.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+    // Acquisition gain
+    expect(taxes["1AJ"]).toEqual(0);
+    expect(taxes["1TZ"]).toEqual(0);
+    expect(taxes["1TT"]).toEqual(0);
+    expect(taxes["1WZ"]).toEqual(0);
+  });
+});
+
+describe("getFrTaxesForNonFrQualifiedSo", () => {
+  it("same day sell", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when daily value is 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-03",
+        qualifiedIn: "us",
+        rateAcquired: 1.12,
+        rateSold: 1.12,
+        symbolPriceAcquired: 100,
+      },
+    ];
+    const taxes = getFrTaxesForNonFrQualifiedSo(
+      { gainsAndLosses, benefits: [] },
+      getEmptyTaxes(),
+    );
+    // No capital gain
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+  });
+  it("capital loss", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 90, // Sold at 90$ when acquired at 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "us",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+    const taxes = getFrTaxesForNonFrQualifiedSo(
+      { gainsAndLosses, benefits: [] },
+      getEmptyTaxes(),
+    );
+    // Capital loss
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 90 / 1.13 = 79.6460176991
+    // capital loss = 79.6460176991 - 89.2857142857 = -9.6396965866
+    expect(taxes["3VG"].toFixed(6)).toEqual("-97.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (Stock Options)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("79.646017");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("796.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("796.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("-97.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+  });
+  it("capital gain", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when acquired at 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "us",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+    const taxes = getFrTaxesForNonFrQualifiedSo(
+      { gainsAndLosses, benefits: [] },
+      getEmptyTaxes(),
+    );
+    // Capital gain
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 110 / 1.13 = 97.3451327434
+    // capital gain = 97.3451327434 - 89.2857142857 = 8.0594184577
+    expect(taxes["3VG"].toFixed(6)).toEqual("80.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (Stock Options)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("97.345132");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("973.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("973.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("80.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+  });
+});
+
+describe("getFrTaxesForNonFrQualifiedRsu", () => {
+  it("same day sell", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when daily value is 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-03",
+        qualifiedIn: "us",
+        rateAcquired: 1.12,
+        rateSold: 1.12,
+        symbolPriceAcquired: 100,
+      },
+    ];
+    const taxes = getFrTaxesForNonFrQualifiedRsu(
+      { gainsAndLosses, benefits: [] },
+      getEmptyTaxes(),
+    );
+    // No capital gain
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+  });
+  it("capital loss", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 90, // Sold at 90$ when acquired at 100$
+        adjustedCost: 0,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "us",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+    const taxes = getFrTaxesForNonFrQualifiedRsu(
+      { gainsAndLosses, benefits: [] },
+      getEmptyTaxes(),
+    );
+    // Capital loss
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 90 / 1.13 = 79.6460176991
+    // capital loss = 79.6460176991 - 89.2857142857 = -9.6396965866
+    expect(taxes["3VG"].toFixed(6)).toEqual("-97.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (RSU)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("79.646017");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("796.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("796.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("-97.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+  });
+  it("capital gain", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 110, // Sold at 110$ when acquired at 100$
+        adjustedCost: 80,
+        acquisitionCost: 0,
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "us",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+      },
+    ];
+    const taxes = getFrTaxesForNonFrQualifiedRsu(
+      { gainsAndLosses, benefits: [] },
+      getEmptyTaxes(),
+    );
+    // Capital gain
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // sellPrice = 110 / 1.13 = 97.3451327434
+    // capital gain = 97.3451327434 - 89.2857142857 = 8.0594184577
+    expect(taxes["3VG"].toFixed(6)).toEqual("80.000000");
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
+    const page510 = taxes["Form 2074"]["Page 510"][0];
+    expect(page510["511"]).toEqual("DDOG (RSU)");
+    expect(page510["512"]).toEqual("09/03/2022");
+    expect(page510["514"].toFixed(6)).toEqual("97.345132");
+    expect(page510["515"]).toEqual(10);
+    expect(page510["516"].toFixed(6)).toEqual("973.000000");
+    expect(page510["517"]).toEqual(0);
+    expect(page510["518"].toFixed(6)).toEqual("973.000000");
+    expect(page510["520"].toFixed(6)).toEqual("89.290000");
+    expect(page510["521"].toFixed(6)).toEqual("893.000000");
+    expect(page510["522"]).toEqual(0);
+    expect(page510["523"].toFixed(6)).toEqual("893.000000");
+    expect(page510["524"].toFixed(6)).toEqual("80.000000");
+    expect(page510["525"]).toEqual(false);
+    expect(page510["526"]).toEqual(0);
+  });
+});

--- a/lib/taxes/taxes-rules-fr.ts
+++ b/lib/taxes/taxes-rules-fr.ts
@@ -1,0 +1,812 @@
+import { SymbolDailyResponse } from "@/lib/symbol-daily.types";
+import {
+  BenefitHistoryEvent,
+  GainAndLossEvent,
+} from "@/lib/etrade/etrade.types";
+import {
+  isEspp,
+  isFrQualifiedRsu,
+  isFrQualifiedSo,
+  isUsQualifiedRsu,
+  isUsQualifiedSo,
+} from "@/lib/etrade/filters";
+import { floorNumber, ceilNumber, formatNumber } from "@/lib/format-number";
+import { TaxableEventFr } from "./taxable-event-fr";
+
+export interface GainAndLossEventWithRates extends GainAndLossEvent {
+  rateAcquired: number;
+  rateSold: number;
+  symbolPriceAcquired: number;
+}
+
+export interface BenefitEventWithRates extends BenefitHistoryEvent {}
+
+/** French taxes uses 6 digit precision for Form 2074 */
+const floorNumber6Digits = (value: number): number => floorNumber(value, 6);
+const floorNumber0Digits = (value: number): number => floorNumber(value, 0);
+const ceilNumber2Digits = (value: number): number => ceilNumber(value, 2);
+const ceilNumber0Digits = (value: number): number => ceilNumber(value, 0);
+
+// Qualified:
+// SO:
+// - Acquisition gain => Income, 1TT: WARNING: use Min(exercise price, sell price)
+// - capital gain =>
+// ESPP:
+// - Acquisition gain => 0
+// - capital gain =>
+// RS:
+// - Acquisition gain < 300k€ => gains/2 1TZ
+// - Acquisition gain >= 300k€ => 1TT
+// - capital gain =>
+//
+// Non-Qualified:
+// SO:
+// - Acquisition gain => Income the year of vesting, split between US and
+// France prorata of time spent in each country. 1AJ. This is treated through
+// payslip, hence there is nothing needed here.
+// - capital gain =>
+// ESPP:
+// - N/A?
+// RS:
+// - Acquisition gain => Income the year of vesting, split between US and
+// France prorata of time spent in each country. 1AJ. This is treated through
+// payslip, hence there is nothing needed here.
+// - capital gain =>
+
+export const enrichEtradeGlFrFr = (
+  data: GainAndLossEvent[],
+  {
+    rates,
+    ddogPrices,
+  }: {
+    rates: {
+      [date: string]: number;
+    };
+    ddogPrices: SymbolDailyResponse;
+  },
+): GainAndLossEventWithRates[] => {
+  return data
+    .sort((a, b) => {
+      // sort by dateSold
+      return new Date(a.dateSold).getTime() - new Date(b.dateSold).getTime();
+    })
+    .map((event) => {
+      const rateAcquired = rates[event.dateAcquired];
+      const rateSold = rates[event.dateSold];
+      const symbolPriceAcquired = ddogPrices[event.dateAcquired].opening;
+
+      return {
+        ...event,
+        rateAcquired: rateAcquired,
+        rateSold: rateSold,
+        symbolPriceAcquired,
+      };
+    });
+};
+
+const enrichEtradeBenefitsFrFr = (
+  data: BenefitHistoryEvent[],
+  {
+    rates,
+    ddogPrices,
+  }: {
+    rates: {
+      [date: string]: number;
+    };
+    ddogPrices: SymbolDailyResponse;
+  },
+): BenefitEventWithRates[] => {
+  return data.map((event) => {
+    const rateAcquired = rates[event.dateVested];
+    const symbolPriceAcquired = ddogPrices[event.dateVested].opening;
+
+    return {
+      ...event,
+      rateAcquired: rateAcquired,
+      symbolPriceAcquired,
+    };
+  });
+};
+
+interface FrTaxesForm2074Page510 {
+  /** Designation */
+  "511": string;
+  /** Date of sale */
+  "512": string;
+  /** Sale price per share, 6 digit precision */
+  "514": number;
+  /** Number of shares sold, 0 digit precision */
+  "515": number;
+  /**
+   * Total sale price (Number of shares sold * Sale price per share).
+   * 0 digit precision
+   */
+  "516": number;
+  /** Cession fees, 0 digit precision */
+  "517": number;
+  /**
+   * Net sale price (Total sale price - Cession fees)
+   * 0 digit precision
+   */
+  "518": number;
+  /** This is a label only */
+  "519": undefined;
+  /** Acquisition value, 2 digits precision */
+  "520": number;
+  /**
+   * Total acquisition cost (Number of shares sold * Price on acquisition date)
+   * 0 digit precision
+   */
+  "521": number;
+  /** Brokerage fees, if any, 0 digit precision */
+  "522": number;
+  /**
+   * Net acquisition cost (Total acquisition cost -  Brokerage fees)
+   * 0 digit precision
+   */
+  "523": number;
+  /**
+   * Net capital gain (Net sale price - Net acquisition cost)
+   * with `-` if negative
+   * 0 digit precision
+   */
+  "524": number;
+  /**
+   * Is there a capital loss due to share invalidation?
+   * This is beyond the scope of this tool given it requires a jugement that
+   * invalidates the shares. If this happens concerned people will know.
+   * Always false.
+   */
+  "525": boolean;
+  /**
+   * Net capital loss for share invalidated.
+   * This is beyond the scope of this tool, always 0
+   */
+  "526": number;
+}
+
+interface FrTaxesExplain {
+  /** Related form box */
+  box: keyof FrTaxes;
+  /** 1 line explanation for the event */
+  description: string;
+  /** Detailed explanation for the event */
+  taxableEvents: TaxableEventFr[];
+}
+
+export interface FrTaxes {
+  /** Explain the computations */
+  explanations: FrTaxesExplain[];
+  /** RSU acquisition gains above 300K€ */
+  "1TT": number;
+  /** RSU acquisition gains below 300K€ */
+  "1TZ": number;
+  /** Tax acquisition rebate for RSU, 50% of 1TZ */
+  "1WZ": number;
+  /** 1AJ OR 1BJ for gains as salaries */
+  "1AJ": number;
+  /** Capital gains */
+  "3VG": number;
+  /** Capital losses Year N-1, we do not know about it, but remind it exists */
+  "3VH": number;
+  /** form No. 2074 */
+  "Form 2074": {
+    /** This is the page to declare a sell */
+    "Page 510": FrTaxesForm2074Page510[];
+    /** Summary of the sales */
+    "Page 900": {
+      /**
+       * capital gains and losses.
+       * Computed from the list of all Page 510
+       */
+      "903": { gains: number; losses: number };
+    };
+    "page 11": {
+      "1133": { gains: number; losses: number };
+    };
+  };
+}
+
+const formatDateForFrTaxes = (date: string) => {
+  const [year, month, day] = date.split("-");
+  return `${day}/${month}/${year}`;
+};
+
+export const getEmptyTaxes = (): FrTaxes => ({
+  explanations: [],
+  "1TT": 0,
+  "1TZ": 0,
+  "1WZ": 0,
+  "1AJ": 0,
+  "3VG": 0,
+  "3VH": 0,
+  "Form 2074": {
+    "Page 510": [],
+    "Page 900": {
+      "903": { gains: 0, losses: 0 },
+    },
+    "page 11": {
+      "1133": { gains: 0, losses: 0 },
+    },
+  },
+});
+
+const getFrTaxesCapitalGain = (
+  {
+    description,
+    taxableEvents,
+  }: {
+    description: string;
+    taxableEvents: TaxableEventFr[];
+  },
+  taxes: FrTaxes,
+) => {
+  if (!taxableEvents.length) {
+    return taxes;
+  }
+  if (taxableEvents.every((event) => event.capitalGain.total === 0)) {
+    return taxes;
+  }
+
+  let capitalGainEur = 0;
+  const newPages: FrTaxes["Form 2074"]["Page 510"] = [];
+
+  taxableEvents.forEach((taxableEvent) => {
+    if (!taxableEvent.sell) {
+      // There is no capital gain if there is no sell
+      return;
+    }
+
+    if (taxableEvent.capitalGain.total === 0) {
+      // There is no capital gain if the total is 0
+      return;
+    }
+
+    const planType = taxableEvent.planType;
+    const planDescription =
+      planType === "SO" ? "Stock Options" : planType === "RS" ? "RSU" : "ESPP";
+
+    const quantity = floorNumber0Digits(taxableEvent.quantity);
+    const cell514 = floorNumber6Digits(taxableEvent.sell.eur);
+    const cell516 = floorNumber0Digits(cell514 * quantity);
+    // There is no small gains, ceiling acquisition value reduces taxable
+    // amount.
+    const cell520 = ceilNumber2Digits(taxableEvent.acquisition.valueEur);
+    const cell521 = ceilNumber0Digits(cell520 * quantity);
+
+    // Add a new page for Form 2074
+    const newPage: FrTaxesForm2074Page510 = {
+      "511": `${taxableEvent.symbol} (${planDescription})`,
+      "512": formatDateForFrTaxes(taxableEvent.sell.date),
+      "514": cell514,
+      "515": quantity,
+      "516": cell516,
+      "517": 0,
+      "518": cell516,
+      "519": undefined,
+      "520": cell520,
+      "521": cell521,
+      "522": 0,
+      "523": cell521,
+      "524": cell516 - cell521,
+      "525": false,
+      "526": 0,
+    };
+
+    // mutate taxableEvent to adjust capital gain as computed with Form 2074
+    taxableEvent.capitalGain.total = newPage["524"];
+    taxableEvent.capitalGain.perShare = cell514 - cell520;
+
+    capitalGainEur += newPage["524"];
+    newPages.push(newPage);
+  });
+
+  // Add the capital gain to the total
+  taxes["3VG"] += capitalGainEur;
+
+  // Add an explanation for the computation
+  taxes.explanations = [
+    ...taxes.explanations,
+    {
+      box: "3VG",
+      description: `${description} (${formatNumber(capitalGainEur)}€ as computed by form 2074)`,
+      taxableEvents,
+    },
+  ];
+  taxes["Form 2074"]["Page 510"] = [
+    ...taxes["Form 2074"]["Page 510"],
+    ...newPages,
+  ];
+
+  return taxes;
+};
+
+/**
+ * Create a FrTaxable event from an E-Trade export item.
+ *
+ * The reason why acquisitionValue, associated rate and acquisitionCost are
+ * provided is that the valid value for tax administration depends on the plan
+ * type.
+ * Every other values are the same for every plans.
+ */
+const getFrTaxableEventFromGainsAndLossEvent = (
+  event: GainAndLossEventWithRates,
+  {
+    acquisitionValueUsd,
+    acquisitionValueRate,
+    acquisitionCostUsd,
+    explainAcquisitionValue,
+  }: {
+    acquisitionValueUsd: number;
+    acquisitionValueRate: number;
+    acquisitionCostUsd: number;
+    /**
+     * Explain how the acquisition value was computed.
+     *
+     * For instance:
+     * - "Use symbol price at opening price on day of exercise."
+     * - "Use symbol price at opening price on day of vesting."
+     * - "Use sell price as acquistion value given the plan is qualified and the sale is at loss."
+     */
+    explainAcquisitionValue: string;
+  },
+): TaxableEventFr => {
+  const sellPriceEur = floorNumber6Digits(event.proceeds / event.rateSold);
+  const acquisitionValueEur = floorNumber6Digits(
+    acquisitionValueUsd / acquisitionValueRate,
+  );
+  const acquisitionCostEur = floorNumber6Digits(
+    acquisitionCostUsd / event.rateAcquired,
+  );
+  const symbolPriceEur = floorNumber6Digits(
+    event.symbolPriceAcquired / event.rateAcquired,
+  );
+
+  return {
+    symbol: event.symbol,
+    planType: event.planType,
+    qualifiedIn: "fr",
+    // ETrade Gans And Losses only lists sell events
+    type: "sell",
+    date: event.dateSold,
+    quantity: event.quantity,
+    sell: {
+      usd: event.proceeds,
+      rate: event.rateSold,
+      eur: sellPriceEur,
+      date: event.dateSold,
+    },
+    acquisition: {
+      valueUsd: acquisitionValueUsd,
+      valueEur: acquisitionValueEur,
+      costUsd: acquisitionCostUsd,
+      costEur: acquisitionCostEur,
+      symbolPrice: event.symbolPriceAcquired,
+      symbolPriceEur,
+      rate: event.rateAcquired,
+      date: event.dateAcquired,
+      description: explainAcquisitionValue,
+    },
+    capitalGain: {
+      perShare: sellPriceEur - acquisitionValueEur,
+      total: (sellPriceEur - acquisitionValueEur) * event.quantity,
+    },
+    acquisitionGain: {
+      perShare: acquisitionValueEur - acquisitionCostEur,
+      total: (acquisitionValueEur - acquisitionCostEur) * event.quantity,
+    },
+  };
+};
+
+export const getFrTaxesForFrQualifiedSo = (
+  {
+    gainsAndLosses,
+  }: {
+    gainsAndLosses: GainAndLossEventWithRates[];
+  },
+  taxes: FrTaxes,
+): FrTaxes => {
+  const qualifiedSo = gainsAndLosses.filter(isFrQualifiedSo);
+  // Explanations for the computations
+  const explanations: FrTaxesExplain[] = [];
+  // buffers for acquisition gains and capital gains
+  let acquisitionGainEur = 0;
+  const taxableEvents: TaxableEventFr[] = [];
+
+  // Process each event
+  qualifiedSo.forEach((event) => {
+    // Convert prices to EUR
+    const sellPriceEur = floorNumber6Digits(event.proceeds / event.rateSold);
+    const priceOnDayOfAcquisitionEur = floorNumber6Digits(
+      event.symbolPriceAcquired / event.rateAcquired,
+    );
+
+    const isSellToCover = event.dateAcquired === event.dateSold;
+    const isSellAtLoss = sellPriceEur < priceOnDayOfAcquisitionEur;
+
+    const taxableEvent = getFrTaxableEventFromGainsAndLossEvent(
+      event,
+      isSellToCover
+        ? {
+            // Sell to cover for qualified stock options:
+            // Acquisition value is the sell price.
+            acquisitionValueUsd: event.proceeds,
+            acquisitionValueRate: event.rateSold,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue:
+              "Use sell price as acquistion value given this is a sell to cover.",
+          }
+        : isSellAtLoss
+          ? {
+              // Sale is at loss, use sell price as acquisition price given the
+              // plan is qualified
+              acquisitionValueUsd: event.proceeds,
+              acquisitionValueRate: event.rateSold,
+              acquisitionCostUsd: event.acquisitionCost,
+              explainAcquisitionValue:
+                "Acquistion value is the sell price given the plan is qualified and the sale is at loss.",
+            }
+          : {
+              // Just use symbol price at opening the day of exercise.
+              acquisitionValueUsd: event.symbolPriceAcquired,
+              acquisitionValueRate: event.rateAcquired,
+              acquisitionCostUsd: event.acquisitionCost,
+              explainAcquisitionValue: `Use ${event.symbol} price at opening on day of exercise.`,
+            },
+    );
+    taxableEvents.push(taxableEvent);
+
+    // Add acquisition gains information
+    acquisitionGainEur += taxableEvent.acquisitionGain.total;
+  });
+
+  const floorAcquisitionGainEur = floorNumber6Digits(acquisitionGainEur);
+  taxes["1TT"] += floorAcquisitionGainEur;
+  explanations.push({
+    box: "1TT",
+    description: `Acquisition gains from Qualified SO sales. (${formatNumber(floorAcquisitionGainEur)}€)`,
+    taxableEvents,
+  });
+  taxes["explanations"] = [...taxes["explanations"], ...explanations];
+  // Add capital gains information to Form 2074
+  taxes = getFrTaxesCapitalGain(
+    {
+      description: "Capital gains from FR qualified SO sales.",
+      taxableEvents,
+    },
+    taxes,
+  );
+
+  return taxes;
+};
+
+export const getFrTaxesForFrQualifiedRsu = (
+  {
+    gainsAndLosses,
+  }: {
+    gainsAndLosses: GainAndLossEventWithRates[];
+  },
+  taxes: FrTaxes,
+): FrTaxes => {
+  const qualifiedRsu = gainsAndLosses.filter(isFrQualifiedRsu);
+  // Explanations for the computations
+  const explanations: FrTaxesExplain[] = [];
+  // buffers for acquisition gains and capital gains
+  let acquisitionGainEur = 0;
+  const taxableEvents: TaxableEventFr[] = [];
+
+  // Process each event
+  qualifiedRsu.forEach((event) => {
+    // Convert prices to EUR
+    const sellPriceEur = floorNumber6Digits(event.proceeds / event.rateSold);
+    const priceOnDayOfAcquisitionEur = floorNumber6Digits(
+      event.symbolPriceAcquired / event.rateAcquired,
+    );
+    const isSellToCover = event.dateAcquired === event.dateSold;
+    const isSellAtLoss = sellPriceEur < priceOnDayOfAcquisitionEur;
+
+    const taxableEvent = getFrTaxableEventFromGainsAndLossEvent(
+      event,
+      isSellToCover
+        ? {
+            // Sell on the same day. This is treated as a sell to cover.
+            // Acquisition value is the sell price.
+            // This event is very unlikely, and the tax rule might be wrong
+            acquisitionValueUsd: event.proceeds,
+            acquisitionValueRate: event.rateSold,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue: [
+              "Use sell price as acquistion value given this is a sell to cover.",
+              "WARNING: implemented tax rule might be wrong for this case.",
+              "Maybe the acquisition price should be the vesting price instead of the sell price.",
+              "If you encouter this message, please contact French taxes support.",
+            ].join("\n"),
+          }
+        : isSellAtLoss
+          ? {
+              // Sale is at loss, use sell price as acquisition price given this
+              // is a qualified plan
+              acquisitionValueUsd: event.proceeds,
+              acquisitionValueRate: event.rateSold,
+              acquisitionCostUsd: event.acquisitionCost,
+              explainAcquisitionValue:
+                "Acquistion value is the sell price given the plan is qualified and the sale is at loss.",
+            }
+          : {
+              // Just use symbol price at opening the day of exercise.
+              acquisitionValueUsd: event.symbolPriceAcquired,
+              acquisitionValueRate: event.rateAcquired,
+              acquisitionCostUsd: event.acquisitionCost,
+              explainAcquisitionValue: `Use ${event.symbol} price at opening on day of exercise.`,
+            },
+    );
+
+    taxableEvents.push(taxableEvent);
+    // Add acquisition gains information
+    acquisitionGainEur += taxableEvent.acquisitionGain.total;
+  });
+
+  const floorAcquisitionGainEur = floorNumber6Digits(acquisitionGainEur);
+  if (acquisitionGainEur > 0) {
+    const discountableAcquisitionGainEur = Math.min(
+      floorAcquisitionGainEur,
+      300_000,
+    );
+    taxes["1TZ"] += floorNumber6Digits(discountableAcquisitionGainEur / 2);
+    explanations.push({
+      box: "1TZ",
+      description: `RSU acquisition gains below 300k€ with 50% discount. (${formatNumber(discountableAcquisitionGainEur)} * 50%)`,
+      taxableEvents,
+    });
+    taxes["1WZ"] += floorNumber6Digits(discountableAcquisitionGainEur / 2);
+    explanations.push({
+      box: "1WZ",
+      description: `Tax acquisition discount for RSU acquisition gains below 300k€ (${formatNumber(discountableAcquisitionGainEur)} * 50%, see 1TZ for calculation details)`,
+      taxableEvents: [],
+    });
+  }
+  if (floorAcquisitionGainEur > 300_000) {
+    taxes["1TT"] += Math.max(floorAcquisitionGainEur - 300_000, 0);
+    explanations.push({
+      box: "1TT",
+      description: `RSU acquisition gains above 300k€ (${formatNumber(floorAcquisitionGainEur)} - 300 000€, see 1TZ for calculation details)`,
+      taxableEvents: [],
+    });
+  }
+  taxes["explanations"] = [...taxes["explanations"], ...explanations];
+  // Add capital gains information to Form 2074
+  taxes = getFrTaxesCapitalGain(
+    {
+      description: "Capital gains from FR qualified RSU sales.",
+      taxableEvents,
+    },
+    taxes,
+  );
+
+  return taxes;
+};
+
+export const getFrTaxesForEspp = (
+  {
+    gainsAndLosses,
+  }: {
+    gainsAndLosses: GainAndLossEventWithRates[];
+  },
+  taxes: FrTaxes,
+): FrTaxes => {
+  const eventsEspp = gainsAndLosses.filter(isEspp);
+  const taxableEvents: TaxableEventFr[] = [];
+
+  // Process each event
+  eventsEspp.forEach((event) => {
+    const taxableEvent: TaxableEventFr = getFrTaxableEventFromGainsAndLossEvent(
+      event,
+      {
+        // ESPP is the only type of plan where the acquisition cost for US
+        // taxes is the same as the acquisition cost for French taxes.
+        acquisitionValueUsd: event.adjustedCost,
+        acquisitionValueRate: event.rateAcquired,
+        acquisitionCostUsd: event.acquisitionCost,
+        explainAcquisitionValue:
+          "Use ESPP value as defined by e-trade for acquisition value.",
+      },
+    );
+
+    taxableEvents.push(taxableEvent);
+  });
+
+  taxes["explanations"] = [
+    ...taxes["explanations"],
+    {
+      box: "1AJ",
+      description:
+        "Acquisition gains from ESPP sales are due the year of acquisition. Already reported by your employer and not yet available in this tool.",
+      taxableEvents: [],
+    },
+  ];
+
+  // Add capital gains
+  taxes = getFrTaxesCapitalGain(
+    { description: "Capital gains from ESPP sales", taxableEvents },
+    taxes,
+  );
+
+  return taxes;
+};
+
+export const getFrTaxesForNonFrQualifiedSo = (
+  {
+    gainsAndLosses,
+  }: {
+    gainsAndLosses: GainAndLossEventWithRates[];
+    benefits: BenefitEventWithRates[];
+  },
+  taxes: FrTaxes,
+): FrTaxes => {
+  // Compute capital gains from gainsAndLosses
+  const nonQualifiedSo = gainsAndLosses.filter((event) =>
+    isUsQualifiedSo(event),
+  );
+  const taxableEvents: TaxableEventFr[] = [];
+
+  nonQualifiedSo.forEach((event) => {
+    const isSellToCover = event.dateAcquired === event.dateSold;
+
+    const taxableEvent = getFrTaxableEventFromGainsAndLossEvent(
+      event,
+      isSellToCover
+        ? {
+            // Sell to cover for stock options:
+            // Acquisition value is the sell price
+            acquisitionValueUsd: event.proceeds,
+            acquisitionValueRate: event.rateSold,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue:
+              "Acquistion value is the sell price given this is a sell to cover.",
+          }
+        : {
+            // Use symbol price
+            acquisitionValueUsd: event.symbolPriceAcquired,
+            acquisitionValueRate: event.rateAcquired,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue: `Use ${event.symbol} price at opening on day of exercise.`,
+          },
+    );
+
+    taxableEvents.push(taxableEvent);
+  });
+
+  if (!taxableEvents.length) {
+    return taxes;
+  }
+
+  taxes["explanations"] = [
+    ...taxes["explanations"],
+    {
+      box: "1AJ",
+      description:
+        "Acquisition gains from non qualified SO are due at vest time. This is already reported by your employer and not yet calculated by this tool.",
+      taxableEvents,
+    },
+  ];
+
+  // Add capital gains information to Form 2074
+  taxes = getFrTaxesCapitalGain(
+    {
+      description: "Capital gains from non FR qualified SO sales.",
+      taxableEvents,
+    },
+    taxes,
+  );
+  return taxes;
+};
+
+export const getFrTaxesForNonFrQualifiedRsu = (
+  {
+    gainsAndLosses,
+  }: {
+    gainsAndLosses: GainAndLossEventWithRates[];
+    benefits: BenefitEventWithRates[];
+  },
+  taxes: FrTaxes,
+): FrTaxes => {
+  const nonQualifiedRsu = gainsAndLosses.filter((event) =>
+    isUsQualifiedRsu(event),
+  );
+  const taxableEvents: TaxableEventFr[] = [];
+
+  // Compute capital gains from gainsAndLosses
+  nonQualifiedRsu.forEach((event) => {
+    const isSellToCover = event.dateAcquired === event.dateSold;
+
+    const taxableEvent = getFrTaxableEventFromGainsAndLossEvent(
+      event,
+      isSellToCover
+        ? {
+            // Sell to cover for RSU:
+            // Acquisition value is the sell price
+            acquisitionValueUsd: event.proceeds,
+            acquisitionValueRate: event.rateSold,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue: [
+              "Use sell price as acquistion value given this is a sell to cover.",
+              "WARNING: implemented tax rule might be wrong for this case.",
+              "Maybe the acquisition price should be the vesting price instead of the sell price.",
+              "If you encouter this message, please contact French taxes support.",
+            ].join("\n"),
+          }
+        : {
+            // Use symbol price
+            acquisitionValueUsd: event.symbolPriceAcquired,
+            acquisitionValueRate: event.rateAcquired,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue: `Use ${event.symbol} price at opening on day of exercise.`,
+          },
+    );
+
+    taxableEvents.push(taxableEvent);
+  });
+
+  if (!taxableEvents.length) {
+    return taxes;
+  }
+
+  taxes["explanations"] = [
+    ...taxes["explanations"],
+    {
+      box: "1AJ",
+      description:
+        "Acquisition gains from non qualified RSUs are due at vest time. This is already reported by your employer and not yet calculated by this tool.",
+      taxableEvents,
+    },
+  ];
+
+  // Add capital gains information to Form 2074
+  taxes = getFrTaxesCapitalGain(
+    {
+      description: "Capital gains from non FR qualified RSU sales.",
+      taxableEvents,
+    },
+    taxes,
+  );
+
+  return taxes;
+};
+
+export const applyFrTaxes = ({
+  gainsAndLosses,
+  benefits,
+  rates,
+  symbolPrices,
+}: {
+  gainsAndLosses: GainAndLossEvent[];
+  benefits: BenefitHistoryEvent[];
+  rates: {
+    [date: string]: number;
+  };
+  symbolPrices: SymbolDailyResponse;
+}): FrTaxes => {
+  return [
+    getFrTaxesForFrQualifiedSo,
+    getFrTaxesForFrQualifiedRsu,
+    getFrTaxesForEspp,
+    getFrTaxesForNonFrQualifiedSo,
+    getFrTaxesForNonFrQualifiedRsu,
+  ].reduce(
+    (taxes, fn) =>
+      fn(
+        {
+          gainsAndLosses: enrichEtradeGlFrFr(gainsAndLosses, {
+            rates,
+            ddogPrices: symbolPrices,
+          }),
+          benefits: enrichEtradeBenefitsFrFr(benefits, {
+            rates,
+            ddogPrices: symbolPrices,
+          }),
+        },
+        taxes,
+      ),
+    getEmptyTaxes(),
+  );
+};


### PR DESCRIPTION
Compute french taxes form from ETrade G&L events.

It introduces nutshell types for benefits (ETrade benefits export) as well but it is not yet parsed or used.

- Introduces a type to reflect FR taxes form with every field affected by share sales
- Introduces rules for every types of plans
- extensive testing

Javascript being Javascript, float computations are sometimes weird (`8.0000000001` instead of `8`).
Given FR taxes precision is limited to 6 digits, in tests every values are checked using `.toFixed(6)`.