### PR TITLE
🐞 Apply % of French origin to loss

### DIFF
--- a/lib/calc-totals.test.ts
+++ b/lib/calc-totals.test.ts
@@ -57,14 +57,14 @@ describe("calcTotals", () => {
           adjustedCost: 200,
           rateAcquired: 1,
           rateSold: 1,
-          fractionFr: 1,
+          fractionFr: 0.8,
         },
       ],
       expected: {
         gain: 0,
         loss: -1000,
         income: 2000,
-        incomeFr: 1000, // income - loss because total gain / loss is < 0
+        incomeFr: 800, // % FR * proceeds because total gain / loss is < 0
         proceeds: 1000,
       },
     },

--- a/lib/calc-totals.ts
+++ b/lib/calc-totals.ts
@@ -53,7 +53,8 @@ export const calcTotals = (events: SaleEventData[]): Totals | null => {
   if (totals) {
     const gainLoss = totals.gain + totals.loss;
     if (gainLoss < 0) {
-      totals.incomeFr += gainLoss;
+      const ratioFr = totals.incomeFr / totals.income;
+      totals.incomeFr += ratioFr * gainLoss;
     }
   }
 


### PR DESCRIPTION
# Motivation

I found a bug with the RSU calculator when you're in the case of a "moins-value". Instead of removing the loss from the French Income, we should be removing the prorated loss.

See unit test for example