### PR TITLE
Use rate of the same day as the grant when the grant date is adjusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ You'll then need to have an alphavantage API key to run the app. You can get one
 free [here](https://www.alphavantage.co/support/#api-key).
 
 Copy the `.env.local.sample` file to `.env.local` and replace the
-`NEXT_PUBLIC_ALPHAVANTAGE_API_KEY` value with your own API key.
+`ALPHA_VANTAGE_API_KEY` value with your own API key.
 
-```
-cp .env.local.example .env.local
+```bash
+cp .env.local.sample .env.local
 ```
 
 Then, run the development server:


### PR DESCRIPTION
Hey, first I want to say thanks for providing this tool, it's super useful! 😃

I found a bug and I fixed it locally to be able to use the tool for my taxes, so here is the fix. There might be a better way to do it and the extra fetching seems to introduce a noticeable extra latency, but I don't plan to invest time to optimize this bug fix because I'm not proficient with Typescript, so feel free to rework it if needed.

---

We sometimes need to adjust the date used to get the grant date symbol price because the grant date can be during a holiday or weekend, when there is no price. In that case, we use the price from the latest day that has a symbol price, before the grant date. However, the app currently forgets to do the same for the rate. So, what happens is that there is sometimes no rate, so the price in EUR ends up being `NaN`, causing all calculations to fail.

<img width="1027" alt="Screenshot 2024-05-20 at 20 50 04" src="https://github.com/hinosxz/tax-helper/assets/32418149/8b876c4e-5ad8-40e2-ba85-caa523dd9c1e">

This PR fixes this issue by fetching the rate of dates between the grant date and 4 days before. Assuming that there are never more than 2 successive holidays, that should cover this case when the grant date is a Sunday and Thursday and Friday happen to be off. Then, the same date as the "adjusted grant date" is used for the rate.

Note that we are fetching the rate for dates that we won't use because we don't know the "adjusted grant date" at that point since symbol prices are getting fetched at the same time.