### PR TITLE
Add more precision to report details

### DIFF
--- a/components/TaxableEventFr.tsx
+++ b/components/TaxableEventFr.tsx
@@ -79,6 +79,7 @@ export const TaxableEventFr: React.FunctionComponent<{
           usd={event.acquisition.costUsd}
           rate={event.acquisition.rate}
           date={event.acquisition.date}
+          precision={7}
         />{" "}
         per share.
       </TaxableEventFrLine>
@@ -88,6 +89,7 @@ export const TaxableEventFr: React.FunctionComponent<{
           usd={event.acquisition.valueUsd}
           rate={event.acquisition.rate}
           date={event.acquisition.date}
+          precision={7}
         />{" "}
         per share ({event.acquisition.description})
       </TaxableEventFrLine>
@@ -105,6 +107,7 @@ export const TaxableEventFr: React.FunctionComponent<{
             usd={event.sell.usd}
             rate={event.sell.rate}
             date={event.sell.date}
+            precision={7}
           />{" "}
           per share.
         </TaxableEventFrLine>
@@ -119,6 +122,7 @@ export const TaxableEventFr: React.FunctionComponent<{
               event.acquisition.dateSymbolPriceAcquired ||
               event.acquisition.date
             }
+            precision={7}
           />{" "}
           at opening on acquisition day.
         </p>
@@ -140,8 +144,12 @@ export const TaxableEventFr: React.FunctionComponent<{
           title="Acquisition gain"
           tooltip={`acq. value - acq. cost: ${event.acquisition.valueEur} - ${event.acquisition.costEur}`}
         >
-          <Currency value={event.acquisitionGain.perShare} unit="eur" /> per
-          share.
+          <Currency
+            value={event.acquisitionGain.perShare}
+            unit="eur"
+            precision={7}
+          />{" "}
+          per share.
         </TaxableEventFrLine>
       )}
       {showCapitalGains && (
@@ -149,7 +157,12 @@ export const TaxableEventFr: React.FunctionComponent<{
           title="Capital gain"
           tooltip={`sell price - acq. cession: ${event.sell?.eur} - ${event.acquisition.valueEur}`}
         >
-          <Currency value={event.capitalGain.perShare} unit="eur" /> per share.
+          <Currency
+            value={event.capitalGain.perShare}
+            unit="eur"
+            precision={7}
+          />{" "}
+          per share.
         </TaxableEventFrLine>
       )}
     </Drawer>

--- a/components/ui/Currency.tsx
+++ b/components/ui/Currency.tsx
@@ -3,10 +3,12 @@ import { formatNumber } from "@/lib/format-number";
 interface CurrencyProps {
   value: number | null;
   unit: "eur" | "usd";
+  /** Number of decimal places to display, default 2 */
+  precision?: number;
 }
 
-export const Currency = ({ value, unit }: CurrencyProps) => {
-  const formattedValue = formatNumber(value);
+export const Currency = ({ value, unit, precision = 2 }: CurrencyProps) => {
+  const formattedValue = formatNumber(value, precision);
   const unitSymbol = unit === "usd" ? "$" : "€";
   return (
     <span className="font-semibold">

--- a/components/ui/PriceInEuro.tsx
+++ b/components/ui/PriceInEuro.tsx
@@ -18,6 +18,8 @@ export interface PriceInEuroProps {
   rate: number;
   /** Date of the conversion rate */
   date: string;
+  /** Number of decimal places to display, default 2 */
+  precision?: number;
 }
 
 export const PriceInEuro: React.FunctionComponent<PriceInEuroProps> = ({
@@ -25,6 +27,7 @@ export const PriceInEuro: React.FunctionComponent<PriceInEuroProps> = ({
   usd,
   rate,
   date,
+  precision = 2,
 }) => {
   const priceInEuro = eur ?? usd / rate;
 
@@ -32,15 +35,17 @@ export const PriceInEuro: React.FunctionComponent<PriceInEuroProps> = ({
     <Tooltip
       content={
         <div>
-          <Currency value={usd} unit="usd" /> at {rate} on {date}
+          <Currency value={usd} unit="usd" precision={precision} /> at {rate} on{" "}
+          {date}
         </div>
       }
     >
       <span>
-        <Currency value={priceInEuro} unit="eur" />
+        <Currency value={priceInEuro} unit="eur" precision={precision} />
         <span className="hidden print:inline">
           {" "}
-          (<Currency value={usd} unit="usd" /> at {rate} $/€ on {date})
+          (<Currency value={usd} unit="usd" precision={precision} /> at {rate}{" "}
+          $/€ on {date})
         </span>
       </span>
     </Tooltip>

--- a/lib/format-number.test.ts
+++ b/lib/format-number.test.ts
@@ -9,11 +9,26 @@ describe("formatNumber", () => {
   it("should add 2 decimal places", () => {
     expect(formatNumber(1)).toBe("1.00");
   });
+  it("should add 2 decimal places", () => {
+    expect(formatNumber(1.1)).toBe("1.10");
+  });
   it("should format a number with 2 decimal places", () => {
     expect(formatNumber(1.234)).toBe("1.23");
   });
   it("should format null", () => {
     expect(formatNumber(null)).toBe("–");
+  });
+  it("should accept precision", () => {
+    expect(formatNumber(1.124, 3)).toBe("1.124");
+  });
+  it("should replace extra 0", () => {
+    expect(formatNumber(1.12, 3)).toBe("1.12");
+  });
+  it("should replace only extra 0s`", () => {
+    expect(formatNumber(1, 5)).toBe("1.00");
+  });
+  it("should multiple replace extra 0", () => {
+    expect(formatNumber(1.12345, 6)).toBe("1.12345");
   });
 });
 

--- a/lib/format-number.ts
+++ b/lib/format-number.ts
@@ -1,3 +1,6 @@
+const ExtraZerosRegex = /(\.)(\d+[1-9])?(0*)$/;
+const extraZeroReplacer = (_: string, p1: string, p2: string = "00") =>
+  `${p1}${p2}`;
 /**
  * Format a number with a fixes 2 decimal places.
  *
@@ -7,8 +10,10 @@
  * formatNumber(null) // "–"
  * ```
  */
-export const formatNumber = (value: number | null): string => {
-  return value?.toFixed(2) ?? "–";
+export const formatNumber = (value: number | null, precision = 2): string => {
+  return (
+    value?.toFixed(precision).replace(ExtraZerosRegex, extraZeroReplacer) ?? "–"
+  );
 };
 
 /**


### PR DESCRIPTION
It was reported some inconsistencies between Form 2074 and details.

This PR adds the ability to add more precision to amounts.

<img width="613" alt="image" src="https://github.com/hinosxz/tax-helper/assets/245501/7619e5fb-1a95-4626-abcc-118bc9416838">
