### PR TITLE
Support assigning custom % of French income

### DIFF
--- a/app/report/_FractionAssignmentModal.tsx
+++ b/app/report/_FractionAssignmentModal.tsx
@@ -36,17 +36,28 @@ export const FractionAssignmentModal = ({
   return (
     <Modal show={showModal}>
       <div className="grid grid-cols-1 gap-4">
-        <div className="flex justify-end">
+        <div className="flex justify-between">
+          <div className="text-lg font-bold">
+            Confirm the origin of your income
+          </div>
           <Button
             onClick={() => setShowModal(false)}
             isBorderless
             icon={XMarkIcon}
           />
         </div>
+        <div>
+          For each sale, please confirm the % of French income. If you have
+          never moved abroad, it should be 100%.
+        </div>
+        <MessageBox level="info" title="Note: this only applies to RSUs.">
+          If you would like support for other types of equity (e.g. stock
+          options), please reach out with examples.
+        </MessageBox>
         {match(state)
           .with("ok", () => (
             <>
-              <div className="grid grid-cols-4">
+              <div className="grid grid-cols-4 gap-4">
                 {["Quantity", "Grant Date", "Acquisition Date", "% FR"].map(
                   (h) => (
                     <div key={h} className="font-semibold">

--- a/app/report/_FractionAssignmentModal.tsx
+++ b/app/report/_FractionAssignmentModal.tsx
@@ -1,0 +1,85 @@
+import { Fragment, useEffect, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { CheckIcon, XMarkIcon } from "@heroicons/react/24/solid";
+import { NumberInput } from "@/components/ui/Field";
+import type { GainAndLossEvent } from "@/lib/etrade/etrade.types";
+import { Modal } from "@/components/ui/Modal";
+
+interface FractionAssignmentModalProps {
+  data: GainAndLossEvent[] | undefined;
+  showModal: boolean;
+  setShowModal: (show: boolean) => void;
+  confirm: (fractions: number[]) => void;
+}
+
+export const FractionAssignmentModal = ({
+  data,
+  showModal,
+  setShowModal,
+  confirm,
+}: FractionAssignmentModalProps) => {
+  // Initialize to 100%
+  const [fractions, setFractions] = useState<number[]>(
+    Array<number>(data?.length ?? 0).fill(100),
+  );
+
+  // Reset fractions if data changes
+  useEffect(() => {
+    setFractions(Array<number>(data?.length ?? 0).fill(100));
+  }, [data, setFractions]);
+
+  return (
+    <Modal show={showModal}>
+      <div className="grid grid-cols-1 gap-4">
+        <div className="flex justify-end">
+          <Button
+            onClick={() => setShowModal(false)}
+            isBorderless
+            icon={XMarkIcon}
+          />
+        </div>
+        <div className="grid grid-cols-4">
+          {["Quantity", "Grant Date", "Acquisition Date", "% FR"].map((h) => (
+            <div key={h} className="font-semibold">
+              {h}
+            </div>
+          ))}
+          {data
+            ?.map((e, eventIdx) => ({ ...e, index: eventIdx }))
+            .filter((e) => e.planType === "RS") // origin of income only applies to RSUs
+            .map((e) => (
+              <Fragment key={`event-${e.index}`}>
+                <div>
+                  {e.quantity}×{e.symbol}
+                </div>
+                <div>{e.dateGranted}</div>
+                <div>{e.dateAcquired}</div>
+                <NumberInput
+                  value={fractions[e.index] ?? 100}
+                  min={0}
+                  max={100}
+                  maxDecimals={2}
+                  onChange={(value) => {
+                    setFractions((prevFractions) =>
+                      prevFractions.map((f, i) => (i === e.index ? value : f)),
+                    );
+                  }}
+                />
+              </Fragment>
+            ))}
+        </div>
+        <div className="flex justify-end">
+          <Button
+            color="green"
+            onClick={() => {
+              confirm(fractions.map((f) => f / 100)); // normalize before sending back
+              setShowModal(false);
+            }}
+            label="Confirm"
+            icon={CheckIcon}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/components/TaxableEventFr.tsx
+++ b/components/TaxableEventFr.tsx
@@ -90,11 +90,13 @@ export const TaxableEventFr: React.FunctionComponent<{
         />{" "}
         per share ({event.acquisition.description})
       </TaxableEventFrLine>
-      <TaxableEventFrLine title="% of French Origin">
-        <span className="font-semibold">
-          {(event.acquisitionGain.fractionFr * 100).toFixed(2)}%
-        </span>
-      </TaxableEventFrLine>
+      {event.acquisitionGain.fractionFr < 1 ? (
+        <TaxableEventFrLine title="% of French Origin">
+          <span className="font-semibold">
+            {(event.acquisitionGain.fractionFr * 100).toFixed(2)}%
+          </span>
+        </TaxableEventFrLine>
+      ) : null}
       {event.sell && (
         <TaxableEventFrLine title="Sell price">
           <PriceInEuro

--- a/components/TaxableEventFr.tsx
+++ b/components/TaxableEventFr.tsx
@@ -90,6 +90,11 @@ export const TaxableEventFr: React.FunctionComponent<{
         />{" "}
         per share ({event.acquisition.description})
       </TaxableEventFrLine>
+      <TaxableEventFrLine title="% of French Origin">
+        <span className="font-semibold">
+          {(event.acquisitionGain.fractionFr * 100).toFixed(2)}%
+        </span>
+      </TaxableEventFrLine>
       {event.sell && (
         <TaxableEventFrLine title="Sell price">
           <PriceInEuro

--- a/components/TaxableEventFr.tsx
+++ b/components/TaxableEventFr.tsx
@@ -6,6 +6,7 @@ import { PriceInEuro } from "./ui/PriceInEuro";
 import { formatDateFr } from "@/lib/date";
 import { Tooltip } from "./ui/Tooltip";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+import { formatNumber } from "@/lib/format-number";
 
 export const TaxableEventFr: React.FunctionComponent<{
   event: TaxableEventFrProps;
@@ -93,7 +94,7 @@ export const TaxableEventFr: React.FunctionComponent<{
       {event.acquisitionGain.fractionFr < 1 ? (
         <TaxableEventFrLine title="% of French Origin">
           <span className="font-semibold">
-            {(event.acquisitionGain.fractionFr * 100).toFixed(2)}%
+            {formatNumber(event.acquisitionGain.fractionFr * 100)}%
           </span>
         </TaxableEventFrLine>
       ) : null}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -3,14 +3,16 @@ import type { ReactNode } from "react";
 
 interface ButtonProps {
   icon?: ({ className }: { className: string }) => ReactNode;
+  isBorderless?: boolean;
   isDisabled?: boolean;
-  label: string;
+  label?: string;
   onClick: () => void;
-  color: "green" | "red";
+  color?: "green" | "red";
 }
 
 export const Button = ({
   icon: Icon,
+  isBorderless,
   isDisabled,
   onClick,
   color,
@@ -18,10 +20,11 @@ export const Button = ({
 }: ButtonProps) => (
   <button
     className={classNames(
-      "flex items-center px-3 py-1.5 rounded shadow",
+      "flex items-center",
       "font-semibold text-sm",
       "hover:opacity-75 disabled:opacity-25",
       {
+        "rounded shadow px-3 py-1.5": !isBorderless,
         "bg-green-200 text-base": color === "green",
         "bg-red-400 text-white": color === "red",
       },
@@ -30,6 +33,9 @@ export const Button = ({
     type="button"
     disabled={isDisabled}
   >
-    {Icon && <Icon className="h-4 w-4 inline mr-1" />} {label}
+    {Icon && (
+      <Icon className={classNames("h-4 w-4 inline", { "mr-1": !!label })} />
+    )}
+    {label && ` ${label}`}
   </button>
 );

--- a/components/ui/Field.tsx
+++ b/components/ui/Field.tsx
@@ -82,7 +82,7 @@ interface NumberInputProps extends BaseInputProps<number> {
   maxDecimals?: 0 | 1 | 2;
 }
 
-const NumberInput = ({
+export const NumberInput = ({
   isLoading,
   isReadOnly,
   isRequired,
@@ -111,7 +111,7 @@ const NumberInput = ({
 
 interface DateInputProps extends BaseInputProps<string> {}
 
-const DateInput = ({
+export const DateInput = ({
   isLoading,
   isReadOnly,
   isRequired,

--- a/components/ui/FileInput.tsx
+++ b/components/ui/FileInput.tsx
@@ -34,6 +34,10 @@ export const FileInput = ({
       id={id}
       type="file"
       disabled={isDisabled}
+      // Clear on every click
+      onClick={(event) => {
+        (event.target as HTMLInputElement).value = "";
+      }}
       onInput={(event) => {
         const file = (event.target as HTMLInputElement).files?.[0];
         onUpload(file);

--- a/components/ui/MessageBox.tsx
+++ b/components/ui/MessageBox.tsx
@@ -1,7 +1,7 @@
 export interface MessageBoxProps {
   level: "info" | "success" | "warning" | "error";
   title: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 const MAP_LEVEL_TO_COLOR = {
@@ -29,8 +29,8 @@ export const MessageBox: React.FunctionComponent<MessageBoxProps> = ({
       className={`border-l-4 p-4 ${MAP_LEVEL_TO_COLOR[level].bg} ${MAP_LEVEL_TO_COLOR[level].border} ${MAP_LEVEL_TO_COLOR[level].text}`}
       role="alert"
     >
-      {title && <h3 className="font-bold pb-2">{title}</h3>}
-      <div>{children}</div>
+      {title && <h3 className="font-semibold">{title}</h3>}
+      {children ? <div className="mt-2">{children}</div> : null}
     </div>
   );
 };

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,22 +1,36 @@
+"use client";
 import classNames from "classnames";
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 interface ModalProps {
   children: ReactNode;
   show: boolean;
 }
 
-export const Modal = ({ show, children }: ModalProps) => {
+const _Modal = ({ show, children }: ModalProps) => {
   return (
     <div
       tabIndex={-1}
-      className={classNames("fixed z-50", "overflow-y-auto overflow-x-hidden", {
-        hidden: !show,
-      })}
+      className={classNames(
+        "fixed inset-x-24 inset-y-12 z-50",
+        "overflow-y-auto overflow-x-hidden",
+        {
+          hidden: !show,
+        },
+      )}
     >
       <div className="relative p-4 bg-gray-100 rounded shadow w-full">
         {children}
       </div>
     </div>
   );
+};
+
+export const Modal = (props: ModalProps) => {
+  // Portalize by default
+  if (typeof window !== "undefined") {
+    return createPortal(<_Modal {...props} />, document.body);
+  }
+  return <_Modal {...props} />;
 };

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,22 @@
+import classNames from "classnames";
+import { ReactNode } from "react";
+
+interface ModalProps {
+  children: ReactNode;
+  show: boolean;
+}
+
+export const Modal = ({ show, children }: ModalProps) => {
+  return (
+    <div
+      tabIndex={-1}
+      className={classNames("fixed z-50", "overflow-y-auto overflow-x-hidden", {
+        hidden: !show,
+      })}
+    >
+      <div className="relative p-4 bg-gray-100 rounded shadow w-full">
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 interface ModalProps {
   children: ReactNode;

--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -15,6 +15,7 @@ export interface GainAndLossEventXlsxRow {
   "Purchase Date Fair Mkt. Value": string | number;
   "Proceeds Per Share": number;
   "Qualified Plan": PlanQualification;
+  "Grant Date": string;
 }
 
 /**
@@ -46,6 +47,7 @@ export interface GainAndLossEvent {
    * This is used for ESPP or SO acquired before IPO.
    */
   purchaseDateFairMktValue: number;
+  dateGranted: string;
   dateAcquired: string;
   dateSold: string;
   /** What kind of qualified plan is it? */

--- a/lib/etrade/parse-etrade-gl.ts
+++ b/lib/etrade/parse-etrade-gl.ts
@@ -26,6 +26,7 @@ export const parseEtradeGL = async (
         symbol: row["Symbol"],
         quantity: row["Qty."],
         proceeds: row["Proceeds Per Share"],
+        dateGranted: row["Grant Date"],
         // FIXME: Adjusted cost from ETrade's G&L is the close price on day acquired,
         // France expects the opening price on day acquired.
         // See https://bofip.impots.gouv.fr/bofip/5654-PGP.html/identifiant%3DBOI-RSA-ES-20-20-20-20170724#:~:text=a.%20Actions%20cot%C3%A9es-,120,-La%20valeur%20%C3%A0

--- a/lib/taxes/taxable-event-fr.ts
+++ b/lib/taxes/taxable-event-fr.ts
@@ -64,5 +64,6 @@ export interface TaxableEventFr {
   acquisitionGain: {
     perShare: number;
     total: number;
+    fractionFr: number;
   };
 }

--- a/lib/taxes/taxes-rules-fr.test.ts
+++ b/lib/taxes/taxes-rules-fr.test.ts
@@ -22,6 +22,7 @@ describe("enrichEtradeGlFrFr", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 78,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-09-09",
         qualifiedIn: "fr",
@@ -37,26 +38,29 @@ describe("enrichEtradeGlFrFr", () => {
         "2022-09-09": { opening: 110, closing: 120 },
       },
     };
-    expect(enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices })).toEqual(
-      [
-        {
-          symbol: "DDOG",
-          planType: "SO",
-          quantity: 10,
-          proceeds: 117,
-          adjustedCost: 80,
-          purchaseDateFairMktValue: 80,
-          acquisitionCost: 78,
-          dateAcquired: "2022-03-03",
-          dateSold: "2022-09-09",
-          qualifiedIn: "fr",
-          rateAcquired: 1.12,
-          rateSold: 1.13,
-          symbolPriceAcquired: 100,
-          dateSymbolPriceAcquired: undefined,
-        },
-      ],
-    );
+    const fractions = [1];
+    expect(
+      enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices, fractions }),
+    ).toEqual([
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 78,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+        dateSymbolPriceAcquired: undefined,
+        fractionFrIncome: 1,
+      },
+    ]);
   });
   it("should use previous day for symbol price if it is not available", () => {
     const gainsAndLosses: GainAndLossEvent[] = [
@@ -68,6 +72,7 @@ describe("enrichEtradeGlFrFr", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 78,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-09-09",
         qualifiedIn: "fr",
@@ -84,26 +89,29 @@ describe("enrichEtradeGlFrFr", () => {
         "2022-09-09": { opening: 110, closing: 120 },
       },
     };
-    expect(enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices })).toEqual(
-      [
-        {
-          symbol: "DDOG",
-          planType: "SO",
-          quantity: 10,
-          proceeds: 117,
-          adjustedCost: 80,
-          purchaseDateFairMktValue: 80,
-          acquisitionCost: 78,
-          dateAcquired: "2022-03-03",
-          dateSold: "2022-09-09",
-          qualifiedIn: "fr",
-          rateAcquired: 1.12,
-          rateSold: 1.13,
-          symbolPriceAcquired: 100,
-          dateSymbolPriceAcquired: "2022-03-02",
-        },
-      ],
-    );
+    const fractions = [1];
+    expect(
+      enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices, fractions }),
+    ).toEqual([
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 78,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+        dateSymbolPriceAcquired: "2022-03-02",
+        fractionFrIncome: 1,
+      },
+    ]);
   });
 
   it("should use adjusted cost for symbol price if it is not available", () => {
@@ -116,6 +124,7 @@ describe("enrichEtradeGlFrFr", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 78,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-09-09",
         qualifiedIn: "fr",
@@ -132,26 +141,30 @@ describe("enrichEtradeGlFrFr", () => {
         "2022-09-09": { opening: 110, closing: 120 },
       },
     };
-    expect(enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices })).toEqual(
-      [
-        {
-          symbol: "DDOG",
-          planType: "SO",
-          quantity: 10,
-          proceeds: 117,
-          adjustedCost: 80,
-          purchaseDateFairMktValue: 80,
-          acquisitionCost: 78,
-          dateAcquired: "2022-03-03",
-          dateSold: "2022-09-09",
-          qualifiedIn: "fr",
-          rateAcquired: 1.12,
-          rateSold: 1.13,
-          symbolPriceAcquired: 80,
-          dateSymbolPriceAcquired: undefined, // cotation date is acquisition date
-        },
-      ],
-    );
+
+    const fractions = [1];
+    expect(
+      enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices, fractions }),
+    ).toEqual([
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 78,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 80,
+        dateSymbolPriceAcquired: undefined, // cotation date is acquisition date
+        fractionFrIncome: 1,
+      },
+    ]);
   });
 });
 
@@ -166,12 +179,14 @@ describe("getFrTaxesForFrQualifiedSo", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 20,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-03",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.12,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
 
@@ -200,12 +215,14 @@ describe("getFrTaxesForFrQualifiedSo", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 20,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
 
@@ -234,12 +251,14 @@ describe("getFrTaxesForFrQualifiedSo", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 20,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
 
@@ -289,12 +308,14 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-03",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.12,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 0.9,
       },
     ];
 
@@ -307,11 +328,11 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
     expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
 
     // Acquisition gain
-    // sellPrice = 110 / 1.12 = 98.2142857143
-    // discount = 98.2142857143 / 2 = 49.1071428571
-    expect(taxes["1TZ"]).toEqual(491.071425);
+    // sellPrice = 110 / 1.12 = 88.3928571429
+    // discount = 88.3928571429 / 2 = 44.1964285714
+    expect(taxes["1TZ"]).toEqual(441.964282);
     expect(taxes["1TT"]).toEqual(0);
-    expect(taxes["1WZ"]).toEqual(491.071425);
+    expect(taxes["1WZ"]).toEqual(441.964282);
   });
 
   it("sell with losses", () => {
@@ -324,12 +345,14 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 0.9,
       },
     ];
 
@@ -341,11 +364,11 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
     expect(taxes["3VG"]).toEqual(0);
     expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
     // Acquisition gain
-    // sellPrice = 90 / 1.13 = 79.6460176991
-    // discount = 79.6460176991 / 2 = 39.8230088495
-    expect(taxes["1TZ"]).toEqual(398.230085);
+    // sellPrice = 90 / 1.13 * 90% = 71.6814159292
+    // discount = 71.6814159292 / 2 = 35.8407079646
+    expect(taxes["1TZ"]).toEqual(358.407076);
     expect(taxes["1TT"]).toEqual(0);
-    expect(taxes["1WZ"]).toEqual(398.230085);
+    expect(taxes["1WZ"]).toEqual(358.407076);
   });
 
   it("sell with gains", () => {
@@ -358,12 +381,14 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 0.9,
       },
     ];
 
@@ -375,12 +400,12 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
     // acquisitionValue = 100 / 1.12 = 89.2857142857
     // sellPrice = 110 / 1.13 = 97.3451327434
     // capital gain = 97.3451327434 - 89.2857142857 = 8.0594184577
-    // acquisition gain = 89.2857142857 - 0 = 89.2857142857
-    // discount = 89.2857142857 / 2 = 44.6428571429
+    // acquisition gain = (89.2857142857 - 0) * 90% = 80.3571428571
+    // discount = 80.3571428571 / 2 = 40.1785714286
     // Acquisition gain
-    expect(taxes["1TZ"]).toEqual(446.42857);
+    expect(taxes["1TZ"]).toEqual(401.785713);
     expect(taxes["1TT"]).toEqual(0);
-    expect(taxes["1WZ"]).toEqual(446.42857);
+    expect(taxes["1WZ"]).toEqual(401.785713);
 
     // Capital gain
     expect(taxes["3VG"].toFixed(6)).toEqual("80.000000");
@@ -414,12 +439,14 @@ describe("getFrTaxesForEspp", () => {
         adjustedCost: 100,
         purchaseDateFairMktValue: 100,
         acquisitionCost: 80,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
 
@@ -461,12 +488,14 @@ describe("getFrTaxesForEspp", () => {
         adjustedCost: 100,
         purchaseDateFairMktValue: 100,
         acquisitionCost: 80,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
 
@@ -512,12 +541,14 @@ describe("getFrTaxesForEspp", () => {
         adjustedCost: 100,
         purchaseDateFairMktValue: 100,
         acquisitionCost: 80,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "fr",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
 
@@ -562,12 +593,14 @@ describe("getFrTaxesForNonFrQualifiedSo", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-03",
         qualifiedIn: "us",
         rateAcquired: 1.12,
         rateSold: 1.12,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
     const taxes = getFrTaxesForNonFrQualifiedSo(
@@ -588,12 +621,14 @@ describe("getFrTaxesForNonFrQualifiedSo", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "us",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
     const taxes = getFrTaxesForNonFrQualifiedSo(
@@ -632,12 +667,14 @@ describe("getFrTaxesForNonFrQualifiedSo", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "us",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
     const taxes = getFrTaxesForNonFrQualifiedSo(
@@ -679,12 +716,14 @@ describe("getFrTaxesForNonFrQualifiedRsu", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-03",
         qualifiedIn: "us",
         rateAcquired: 1.12,
         rateSold: 1.12,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
     const taxes = getFrTaxesForNonFrQualifiedRsu(
@@ -705,12 +744,14 @@ describe("getFrTaxesForNonFrQualifiedRsu", () => {
         adjustedCost: 0,
         purchaseDateFairMktValue: 100.6,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "us",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
     const taxes = getFrTaxesForNonFrQualifiedRsu(
@@ -749,12 +790,14 @@ describe("getFrTaxesForNonFrQualifiedRsu", () => {
         adjustedCost: 80,
         purchaseDateFairMktValue: 80,
         acquisitionCost: 0,
+        dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",
         dateSold: "2022-03-09",
         qualifiedIn: "us",
         rateAcquired: 1.12,
         rateSold: 1.13,
         symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
       },
     ];
     const taxes = getFrTaxesForNonFrQualifiedRsu(

--- a/lib/taxes/taxes-rules-fr.ts
+++ b/lib/taxes/taxes-rules-fr.ts
@@ -840,15 +840,15 @@ export const getFrTaxesForNonFrQualifiedRsu = (
     return taxes;
   }
 
-  // FIXME, we're assuming here that the user has already vested all of their RSUs.
-  // They might still be vesting and would have a fraction of acquisition gain to report in France.
-
+  // FIXME calculate acquisition gain on non-qualified RSUs
+  // (% of French Origin must be taken into accout)
   taxes["explanations"] = [
     ...taxes["explanations"],
     {
       box: "1AJ",
-      description:
-        "Acquisition gains from non qualified RSUs are due at vest time. This is already reported by your employer and not yet calculated by this tool.",
+      description: `Acquisition gain from non-qualified RSUs are due at vest time. 
+        That should already have been reported by your employer 
+        and is not yet calculated by this tool.`,
       taxableEvents,
     },
   ];

--- a/lib/taxes/taxes-rules-fr.ts
+++ b/lib/taxes/taxes-rules-fr.ts
@@ -22,6 +22,11 @@ export interface GainAndLossEventWithRates extends GainAndLossEvent {
   rateAcquired: number;
   rateSold: number;
   symbolPriceAcquired: number;
+  /** People that have spent time abroad and have vested stocks in another country
+   * will only have a fraction of the income to report to the French authorities.
+   * 0 < `fractionFrIncome` < 1. By default, fractionFrIncome = 1.
+   */
+  fractionFrIncome: number;
   /**
    * Sometimes grant date is on a weekend.
    * This leads to a missing symbol price since markets are closed.
@@ -98,6 +103,7 @@ const getAdjustedSymbolDate = (
 export const enrichEtradeGlFrFr = (
   data: GainAndLossEvent[],
   {
+    fractions,
     rates,
     symbolPrices,
   }: {
@@ -105,6 +111,7 @@ export const enrichEtradeGlFrFr = (
       [date: string]: number;
     };
     symbolPrices: { [symbol: string]: SymbolDailyResponse };
+    fractions: number[];
   },
 ): GainAndLossEventWithRates[] => {
   return data
@@ -112,7 +119,7 @@ export const enrichEtradeGlFrFr = (
       // sort by dateSold
       return new Date(a.dateSold).getTime() - new Date(b.dateSold).getTime();
     })
-    .map((event) => {
+    .map((event, eventIdx) => {
       const rateAcquired = rates[event.dateAcquired];
       const rateSold = rates[event.dateSold];
       const dateSymbolPriceAcquired = getAdjustedSymbolDate(
@@ -132,6 +139,7 @@ export const enrichEtradeGlFrFr = (
           dateSymbolPriceAcquired !== event.dateAcquired
             ? dateSymbolPriceAcquired
             : undefined,
+        fractionFrIncome: fractions[eventIdx],
       };
     });
 };
@@ -400,7 +408,7 @@ const getFrTaxableEventFromGainsAndLossEvent = (
      * For instance:
      * - "Use symbol price at opening price on day of exercise."
      * - "Use symbol price at opening price on day of vesting."
-     * - "Use sell price as acquistion value given the plan is qualified and the sale is at loss."
+     * - "Use sell price as acquisition value given the plan is qualified and the sale is at loss."
      */
     explainAcquisitionValue: string;
   },
@@ -447,8 +455,13 @@ const getFrTaxableEventFromGainsAndLossEvent = (
       total: (sellPriceEur - acquisitionValueEur) * event.quantity,
     },
     acquisitionGain: {
-      perShare: acquisitionValueEur - acquisitionCostEur,
-      total: (acquisitionValueEur - acquisitionCostEur) * event.quantity,
+      perShare:
+        (acquisitionValueEur - acquisitionCostEur) * event.fractionFrIncome,
+      total:
+        (acquisitionValueEur - acquisitionCostEur) *
+        event.fractionFrIncome *
+        event.quantity,
+      fractionFr: event.fractionFrIncome,
     },
   };
 };
@@ -489,7 +502,7 @@ export const getFrTaxesForFrQualifiedSo = (
             acquisitionValueRate: event.rateSold,
             acquisitionCostUsd: event.acquisitionCost,
             explainAcquisitionValue:
-              "Use sell price as acquistion value given this is a sell to cover.",
+              "Use sell price as acquisition value given this is a sell to cover.",
           }
         : isSellAtLoss
           ? {
@@ -499,7 +512,7 @@ export const getFrTaxesForFrQualifiedSo = (
               acquisitionValueRate: event.rateSold,
               acquisitionCostUsd: event.acquisitionCost,
               explainAcquisitionValue:
-                "Acquistion value is the sell price given the plan is qualified and the sale is at loss.",
+                "Acquisition value is the sell price given the plan is qualified and the sale is at loss.",
             }
           : {
               // Just use symbol price at opening the day of exercise.
@@ -571,7 +584,7 @@ export const getFrTaxesForFrQualifiedRsu = (
             acquisitionValueRate: event.rateSold,
             acquisitionCostUsd: event.acquisitionCost,
             explainAcquisitionValue: [
-              "Use sell price as acquistion value given this is a sell to cover.",
+              "Use sell price as acquisition value given this is a sell to cover.",
               "WARNING: implemented tax rule might be wrong for this case.",
               "Maybe the acquisition price should be the vesting price instead of the sell price.",
               "If you encouter this message, please contact French taxes support.",
@@ -585,7 +598,7 @@ export const getFrTaxesForFrQualifiedRsu = (
               acquisitionValueRate: event.rateSold,
               acquisitionCostUsd: event.acquisitionCost,
               explainAcquisitionValue:
-                "Acquistion value is the sell price given the plan is qualified and the sale is at loss.",
+                "Acquisition value is the sell price given the plan is qualified and the sale is at loss.",
             }
           : {
               // Just use symbol price at opening the vesting day.
@@ -738,7 +751,7 @@ export const getFrTaxesForNonFrQualifiedSo = (
             acquisitionValueRate: event.rateSold,
             acquisitionCostUsd: event.acquisitionCost,
             explainAcquisitionValue:
-              "Acquistion value is the sell price given this is a sell to cover.",
+              "Acquisition value is the sell price given this is a sell to cover.",
           }
         : {
             // Use symbol price
@@ -805,10 +818,10 @@ export const getFrTaxesForNonFrQualifiedRsu = (
             acquisitionValueRate: event.rateSold,
             acquisitionCostUsd: event.acquisitionCost,
             explainAcquisitionValue: [
-              "Use sell price as acquistion value given this is a sell to cover.",
+              "Use sell price as acquisition value given this is a sell to cover.",
               "WARNING: implemented tax rule might be wrong for this case.",
               "Maybe the acquisition price should be the vesting price instead of the sell price.",
-              "If you encouter this message, please contact French taxes support.",
+              "If you encounter this message, please contact French taxes support.",
             ].join("\n"),
           }
         : {
@@ -826,6 +839,9 @@ export const getFrTaxesForNonFrQualifiedRsu = (
   if (!taxableEvents.length) {
     return taxes;
   }
+
+  // FIXME, we're assuming here that the user has already vested all of their RSUs.
+  // They might still be vesting and would have a fraction of acquisition gain to report in France.
 
   taxes["explanations"] = [
     ...taxes["explanations"],
@@ -854,6 +870,7 @@ export const applyFrTaxes = ({
   benefits,
   rates,
   symbolPrices,
+  fractions,
 }: {
   gainsAndLosses: GainAndLossEvent[];
   benefits: BenefitHistoryEvent[];
@@ -863,6 +880,7 @@ export const applyFrTaxes = ({
   symbolPrices: {
     [symbol: string]: SymbolDailyResponse;
   };
+  fractions: number[];
 }): FrTaxes => {
   return [
     getFrTaxesForFrQualifiedSo,
@@ -877,6 +895,7 @@ export const applyFrTaxes = ({
           gainsAndLosses: enrichEtradeGlFrFr(gainsAndLosses, {
             rates,
             symbolPrices,
+            fractions,
           }),
           benefits: enrichEtradeBenefitsFrFr(benefits, {
             rates,


### PR DESCRIPTION
# Motivation

Users having spent time in both France and another country only have a portion of their RSU income to report to the French authorities. This PR adds support for attributing those % when importing the ETrade file.

# Changes

<img width="571" alt="image" src="https://github.com/hinosxz/tax-helper/assets/33065180/f52c7b62-3fba-4aa3-9b29-0c324e3e0dfc">

<img width="1549" alt="image" src="https://github.com/hinosxz/tax-helper/assets/33065180/ba3af1b3-59e8-4909-bcdb-e31ffbce3f41">
