### PR TITLE
[Fix] Tax report not being shown when g&l contains no RSU

### DIFF
--- a/app/report/_ReportResidencyFrTaxesFr.tsx
+++ b/app/report/_ReportResidencyFrTaxesFr.tsx
@@ -124,7 +124,9 @@ export const ReportResidencyFrTaxesFr: React.FunctionComponent<
           Benefit History) from Etrade.
         </div>
       </div>
-      {gainsAndLosses.length === 0 || fractionsFrIncome.length === 0 ? (
+      {gainsAndLosses.length === 0 ||
+      (gainsAndLosses.filter((e) => e.planType === "RS").length > 0 &&
+        fractionsFrIncome.length === 0) ? (
         <div className="flex items-baseline justify-center gap-3">
           <span>Import the Gains and Losses CSV file: </span>
           <FractionAssignmentModal


### PR DESCRIPTION
### Motivation
It seems that PR https://github.com/hinosxz/tax-helper/pull/28 introduced a bug where the report was not shown when `gainsAndLosses` doesn't contain any RSU

### Changes
 
#### Previous behavior
https://github.com/user-attachments/assets/daa02fda-dcab-467e-8e60-cd07a5618e94

#### New behavior
https://github.com/user-attachments/assets/892c3514-33ae-4131-a994-0e90d3847911

