### PR TITLE
[report] use && instead of ||

### DIFF
--- a/app/report/_ReportResidencyFrTaxesFr.tsx
+++ b/app/report/_ReportResidencyFrTaxesFr.tsx
@@ -124,7 +124,7 @@ export const ReportResidencyFrTaxesFr: React.FunctionComponent<
           Benefit History) from Etrade.
         </div>
       </div>
-      {gainsAndLosses.length === 0 || fractionsFrIncome.length === 0 ? (
+      {gainsAndLosses.length === 0 && fractionsFrIncome.length === 0 ? (
         <div className="flex items-baseline justify-center gap-3">
           <span>Import the Gains and Losses CSV file: </span>
           <FractionAssignmentModal


### PR DESCRIPTION
## Why?

After import, the page is blank:

<img width="1372" alt="image" src="https://github.com/user-attachments/assets/10dafbc3-2c63-47ee-9fde-4ebf843f3316" />

## Changes

Use `&&`

We can see here that the variable `fractionsFrIncome` is an empty array in some cases:
<img width="614" alt="image" src="https://github.com/user-attachments/assets/5a15e17c-7a9a-4c96-a129-c43743e9e6ba" />

I think this is a regression after https://github.com/hinosxz/tax-helper/pull/28

## Test

Before | After
-|-
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/f956ba91-cb06-44aa-8590-812eda6c4775" /> | <img width="1358" alt="image" src="https://github.com/user-attachments/assets/8ab09c7f-9719-4eda-8bf6-42cceff761f8" />

