### PR TITLE
Fixes SO report as there is no fractionFRIncome associated

### DIFF
--- a/lib/taxes/taxes-rules-fr.test.ts
+++ b/lib/taxes/taxes-rules-fr.test.ts
@@ -62,6 +62,56 @@ describe("enrichEtradeGlFrFr", () => {
       },
     ]);
   });
+  it("should assign 100% if fractionFrIncome does not exist", () => {
+    const gainsAndLosses: GainAndLossEvent[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 78,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+      },
+    ];
+    const rates = {
+      "2022-03-03": 1.12,
+      "2022-09-09": 1.13,
+    };
+    const symbolPrices: { [symbol: string]: SymbolDailyResponse } = {
+      DDOG: {
+        "2022-03-03": { opening: 100, closing: 110 },
+        "2022-09-09": { opening: 110, closing: 120 },
+      },
+    };
+    const fractions: number[] = [];
+    expect(
+      enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices, fractions }),
+    ).toEqual([
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 78,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 100,
+        dateSymbolPriceAcquired: undefined,
+        fractionFrIncome: 1,
+      },
+    ]);
+  });
   it("should use previous day for symbol price if it is not available", () => {
     const gainsAndLosses: GainAndLossEvent[] = [
       {

--- a/lib/taxes/taxes-rules-fr.ts
+++ b/lib/taxes/taxes-rules-fr.ts
@@ -139,7 +139,7 @@ export const enrichEtradeGlFrFr = (
           dateSymbolPriceAcquired !== event.dateAcquired
             ? dateSymbolPriceAcquired
             : undefined,
-        fractionFrIncome: fractions[eventIdx],
+        fractionFrIncome: eventIdx in fractions ? fractions[eventIdx] : 1,
       };
     });
 };


### PR DESCRIPTION
As reported by several people, there is some cases where the app shows `NaN`

This PR ensures there always is a `fractionFrIncome` defined

![image](https://github.com/user-attachments/assets/2e5925a1-af59-4d6d-bebb-6c473488bbf8)
