### PR TITLE
Fix `npm build` requires `ALPHA_VANTAGE_API_KEY`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  }
 }

--- a/app/api/stock/[symbol]/daily/route.ts
+++ b/app/api/stock/[symbol]/daily/route.ts
@@ -18,19 +18,29 @@ const cachedData: {
 } = {};
 
 const apiUrl = "https://www.alphavantage.co/query";
-if (!process.env.ALPHA_VANTAGE_API_KEY) {
-  throw new Error(`
-    ALPHA_VANTAGE_API_KEY is not set.
-    Please set it in your .env.local file.
+let apiKey = "";
 
-    To create a new API key, visit: https://www.alphavantage.co/support/#api-key
-    `);
-}
+const loadApiKey = () => {
+  if (!process.env.ALPHA_VANTAGE_API_KEY) {
+    throw new Error(`
+      [env:${process.env.NODE_ENV}] 
+      ALPHA_VANTAGE_API_KEY is not set.
+      Please set it in your .env.local file.
+  
+      To create a new API key, visit: https://www.alphavantage.co/support/#api-key
+      `);
+  }
+  apiKey = process.env.ALPHA_VANTAGE_API_KEY;
+};
 
 export async function GET(
   _request: Request,
   { params }: { params: { symbol: string } },
 ) {
+  if (!apiKey) {
+    loadApiKey();
+  }
+
   const symbol = params.symbol;
   try {
     const cache = cachedData[symbol];
@@ -39,7 +49,7 @@ export async function GET(
         function: "TIME_SERIES_DAILY",
         symbol,
         outputsize: "full",
-        apikey: process.env.ALPHA_VANTAGE_API_KEY || "",
+        apiKey,
       });
       cachedData[symbol] = await fetch(`${apiUrl}?${searchParams.toString()}`)
         .then((res) => res.json())

--- a/app/api/stock/[symbol]/daily/route.ts
+++ b/app/api/stock/[symbol]/daily/route.ts
@@ -2,15 +2,17 @@ import { ONE_DAY } from "@/lib/constants";
 import type { ApiDate, SymbolDailyResponse } from "@/lib/symbol-daily.types";
 
 export interface SymbolDailyAlphavantageResponse {
-  "Time Series (Daily)": {
-    [date: ApiDate]: {
-      "1. open": string;
-      "2. high": string;
-      "3. low": string;
-      "4. close": string;
-      "5. volume": string;
-    };
-  };
+  "Time Series (Daily)":
+    | {
+        [date: ApiDate]: {
+          "1. open": string;
+          "2. high": string;
+          "3. low": string;
+          "4. close": string;
+          "5. volume": string;
+        };
+      }
+    | undefined;
 }
 
 const cachedData: {
@@ -49,15 +51,21 @@ export async function GET(
         function: "TIME_SERIES_DAILY",
         symbol,
         outputsize: "full",
-        apiKey,
+        apikey: apiKey,
       });
       cachedData[symbol] = await fetch(`${apiUrl}?${searchParams.toString()}`)
         .then((res) => res.json())
         .then((response: SymbolDailyAlphavantageResponse) => {
+          if ("Error Message" in response) {
+            throw new Error(
+              `Failed to fetch symbol ${symbol} prices with: "${response["Error Message"]}"`,
+            );
+          }
           const data: SymbolDailyResponse = {};
-          for (const [date, values] of Object.entries(
-            response["Time Series (Daily)"],
-          )) {
+          const dailyTs = response["Time Series (Daily)"]
+            ? Object.entries(response["Time Series (Daily)"])
+            : [];
+          for (const [date, values] of dailyTs) {
             data[date] = {
               opening: parseFloat(values["1. open"]),
               closing: parseFloat(values["4. close"]),


### PR DESCRIPTION
# Motivation

`npm build` used to require the Alpha Vantage API Key to be set which broke in every PR originating from a fork

# Changes

API Key is now loaded async, on the first API call