### PR TITLE
Fixes #36: `purchaseDateFairMktValue` can be empty in e-trade export

### DIFF
--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -25,6 +25,9 @@ export interface GainAndLossEvent {
   planType: PlanType;
   symbol: string;
   quantity: number;
+  dateGranted: string;
+  dateAcquired: string;
+  dateSold: string;
   /** Proceeds per share in USD: sell price. */
   proceeds: number;
   /**
@@ -45,8 +48,10 @@ export interface GainAndLossEvent {
   /**
    * Fair market value of the share at the time of purchase.
    * This is used for ESPP or SO acquired before IPO.
+   * ⚠️  This can be empty or 0, in this case, the `adjustedCost` is used.
    */
   purchaseDateFairMktValue: number;
+  /**
   dateGranted: string;
   dateAcquired: string;
   dateSold: string;

--- a/lib/taxes/taxes-rules-fr.test.ts
+++ b/lib/taxes/taxes-rules-fr.test.ts
@@ -164,14 +164,14 @@ describe("enrichEtradeGlFrFr", () => {
     ]);
   });
 
-  it("should use adjusted cost for symbol price if it is not available", () => {
+  it("should use purchaseDateFairMktValue for symbol price if it is not available", () => {
     const gainsAndLosses: GainAndLossEvent[] = [
       {
         symbol: "DDOG",
         planType: "SO",
         quantity: 10,
         proceeds: 117,
-        adjustedCost: 80,
+        adjustedCost: 333, // This should be the same value as purchaseDateFairMktValue but for the sake of test it is not
         purchaseDateFairMktValue: 80,
         acquisitionCost: 78,
         dateGranted: "2021-03-03",
@@ -201,8 +201,60 @@ describe("enrichEtradeGlFrFr", () => {
         planType: "SO",
         quantity: 10,
         proceeds: 117,
-        adjustedCost: 80,
+        adjustedCost: 333,
         purchaseDateFairMktValue: 80,
+        acquisitionCost: 78,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1.12,
+        rateSold: 1.13,
+        symbolPriceAcquired: 80,
+        dateSymbolPriceAcquired: undefined, // cotation date is acquisition date
+        fractionFrIncome: 1,
+      },
+    ]);
+  });
+  it("should  use adjusted cost for symbol price if symbol and purchaseDateFairMktValue are unavailable", () => {
+    const gainsAndLosses: GainAndLossEvent[] = [
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 0,
+        acquisitionCost: 78,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-09-09",
+        qualifiedIn: "fr",
+      },
+    ];
+    const rates = {
+      "2022-03-03": 1.12,
+      "2022-09-09": 1.13,
+    };
+    const symbolPrices: { [symbol: string]: SymbolDailyResponse } = {
+      DDOG: {
+        // There is no price for 2022-03-03
+        "2022-02-02": { opening: 100, closing: 110 },
+        "2022-09-09": { opening: 110, closing: 120 },
+      },
+    };
+
+    const fractions = [1];
+    expect(
+      enrichEtradeGlFrFr(gainsAndLosses, { rates, symbolPrices, fractions }),
+    ).toEqual([
+      {
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 117,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 0,
         acquisitionCost: 78,
         dateGranted: "2021-03-03",
         dateAcquired: "2022-03-03",

--- a/lib/taxes/taxes-rules-fr.ts
+++ b/lib/taxes/taxes-rules-fr.ts
@@ -128,7 +128,10 @@ export const enrichEtradeGlFrFr = (
       );
       const symbolPriceAcquired = dateSymbolPriceAcquired
         ? symbolPrices[event.symbol][dateSymbolPriceAcquired].opening
-        : event.purchaseDateFairMktValue; // Given the symbol was not publicly traded, use the Fair Market Value
+        : event.purchaseDateFairMktValue &&
+            !Number.isNaN(event.purchaseDateFairMktValue)
+          ? event.purchaseDateFairMktValue // Given the symbol was not publicly traded, use the Fair Market Value
+          : Number(event.adjustedCost); // Use the adjusted cost basis per share as last resort if purchaseDateFairMktValue is not available
 
       return {
         ...event,


### PR DESCRIPTION
Use `Adjusted Cost Basis Per Share` if `purchaseDateFairMktValue` is not available