### PR TITLE
Query ECB in the back to cache responses

### DIFF
--- a/app/api/euro/[date]/route.ts
+++ b/app/api/euro/[date]/route.ts
@@ -1,0 +1,75 @@
+const API_BASE_URL =
+  "https://data-api.ecb.europa.eu/service/data/EXR/D.USD.EUR.SP00.A";
+
+interface Series {
+  "0:0:0:0:0": {
+    observations: {
+      "0": [number];
+    };
+  };
+}
+interface DataSet {
+  action: string;
+  validFrom: string;
+  series: Series;
+}
+interface Response {
+  dataSets: DataSet[];
+}
+
+const baseFetchExchangeRate = async (date: string): Promise<number> => {
+  const url = new URL(API_BASE_URL);
+  url.searchParams.set("format", "jsondata");
+  url.searchParams.set("detail", "dataonly");
+  url.searchParams.set("startPeriod", date);
+  url.searchParams.set("endPeriod", date);
+
+  return fetch(url)
+    .then((res) => res.json())
+    .then(
+      (data: Response) =>
+        data.dataSets[0].series["0:0:0:0:0"].observations[0][0],
+    );
+};
+
+/**
+ * Use a Map of promises instead of map of numbers, so that if we receive 2 requests at the same time on the same date,
+ * we can start only 1, and use the same promise for both.
+ */
+const CACHE_EXCHANGE_RATE_PROMISES = new Map<string, Promise<number>>();
+const fetchExchangeRate = async (date: string): Promise<number> => {
+  const cachedPromiseExchangeRate = CACHE_EXCHANGE_RATE_PROMISES.get(date);
+  if (cachedPromiseExchangeRate != null) {
+    return cachedPromiseExchangeRate;
+  }
+
+  const exchangeRatePromise = baseFetchExchangeRate(date);
+  // Eagerly set in the cache
+  CACHE_EXCHANGE_RATE_PROMISES.set(date, exchangeRatePromise);
+
+  // Auto clean if the promise throws (only keep clean ones in the cache)
+  exchangeRatePromise.catch(() => {
+    CACHE_EXCHANGE_RATE_PROMISES.delete(date);
+  });
+
+  return exchangeRatePromise;
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { date: string } },
+) {
+  try {
+    const exchangeRate = await fetchExchangeRate(params.date);
+    return Response.json(exchangeRate, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return Response.json(
+      {
+        error:
+          (error as Error).message || `Failed to fetch euro for ${params.date}`,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/hooks/use-fetch-exr.ts
+++ b/hooks/use-fetch-exr.ts
@@ -4,46 +4,14 @@ import { useQueries } from "@tanstack/react-query";
 import { useBankHolidays } from "./use-bank-holiday";
 import { dayBefore, isWeekend } from "@/lib/date";
 
-const apiUrl =
-  "https://data-api.ecb.europa.eu/service/data/EXR/D.USD.EUR.SP00.A";
-
-interface Series {
-  "0:0:0:0:0": {
-    observations: {
-      "0": [number];
-    };
-  };
-}
-interface DataSet {
-  action: string;
-  validFrom: string;
-  series: Series;
-}
-interface Response {
-  dataSets: DataSet[];
-}
-
-// @deprecated use useExchangeRates instead
-export interface ExchangeRate {
-  rate: number | null;
-  isFetching: boolean;
-  errorMessage: string | null;
-}
+const apiUrl = "/api/euro/{date}";
 
 const fetchExchangeRate = async (date: string): Promise<number> => {
-  const searchParams = new URLSearchParams({
-    format: "jsondata",
-    detail: "dataonly",
-  });
-  searchParams.set("startPeriod", date);
-  searchParams.set("endPeriod", date);
-
-  return fetch(`${apiUrl}?${searchParams.toString()}`)
+  return fetch(`${apiUrl.replace("{date}", date)}`)
     .then((res) => res.json())
-    .then(
-      (data: Response) =>
-        data.dataSets[0].series["0:0:0:0:0"].observations[0][0],
-    );
+    .then((response: number) => {
+      return response;
+    });
 };
 
 interface UseExchangeRateResponse {


### PR DESCRIPTION
Instead of having the FE do all the requests, make them in the BE and cache the results