### PR TITLE
Fixes ETrade 2025 format

### DIFF
--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -4,7 +4,7 @@ export type PlanQualification = "Qualified" | "Non-Qualified";
 /**
  * Original format for the XLSX file rows in the Etrade Gain/Loss report.
  */
-export interface GainAndLossEventXlsxRow {
+export interface GainAndLossEventXlsxRowPrior2025 {
   "Plan Type": PlanType;
   Symbol: string;
   "Qty.": number;
@@ -17,6 +17,23 @@ export interface GainAndLossEventXlsxRow {
   "Qualified Plan": PlanQualification;
   "Grant Date": string;
 }
+export interface GainAndLossEventXlsxRow2025 {
+  "Plan Type": PlanType;
+  Symbol: string;
+  Quantity: number;
+  "Date Acquired": string;
+  "Date Sold": string;
+  "Adjusted Cost Basis Per Share": number;
+  "Acquisition Cost Per Share": number;
+  "Purchase Date Fair Mkt. Value": string | number;
+  "Proceeds Per Share": number;
+  "Qualified Plan": PlanQualification;
+  "Grant Date": string;
+}
+
+export type GainAndLossEventXlsxRow =
+  | GainAndLossEventXlsxRowPrior2025
+  | GainAndLossEventXlsxRow2025;
 
 /**
  * Data format for a single sale event after parsing the Etrade Gain/Loss report.

--- a/lib/etrade/parse-etrade-gl.ts
+++ b/lib/etrade/parse-etrade-gl.ts
@@ -9,6 +9,62 @@ import XLSX from "xlsx";
 const toDateString = (rawDate: string) =>
   getDateString(parseEtradeDate(rawDate));
 
+const toNumber = (rawNumber: string | number): number => {
+  const result = typeof rawNumber === "string" ? Number(rawNumber) : rawNumber;
+  if (isNaN(result)) {
+    throw new Error(`invalid number: ${rawNumber}`);
+  }
+
+  return result;
+};
+
+const ensureDefined = <T>(value: T | undefined, key: string): T => {
+  if (value === undefined || value === null || value === "") {
+    throw new Error(`undefined value for ${key}`);
+  }
+  return value;
+};
+
+const parseEtradeGLRow = (row: GainAndLossEventXlsxRow): GainAndLossEvent => {
+  const planType = row["Plan Type"];
+  const symbol = row["Symbol"];
+  const quantity = toNumber("Qty." in row ? row["Qty."] : row["Quantity"]);
+  const dateGranted = toDateString(row["Grant Date"]);
+  const dateAcquired = toDateString(row["Date Acquired"]);
+  const dateSold = toDateString(row["Date Sold"]);
+  const proceeds = toNumber(row["Proceeds Per Share"]);
+  // FIXME: Adjusted cost from ETrade's G&L is the close price on day acquired,
+  // France expects the opening price on day acquired.
+  // See https://bofip.impots.gouv.fr/bofip/5654-PGP.html/identifiant%3DBOI-RSA-ES-20-20-20-20170724#:~:text=a.%20Actions%20cot%C3%A9es-,120,-La%20valeur%20%C3%A0
+  const adjustedCost = toNumber(row["Adjusted Cost Basis Per Share"]);
+  const acquisitionCost = toNumber(row["Acquisition Cost Per Share"]);
+  // It's unclear why this is a string and not a number.
+  const purchaseDateFairMktValue = toNumber(
+    row["Purchase Date Fair Mkt. Value"],
+  );
+  // For now consider that a non-US qualified plan is FR qualified.
+  // FIXME: this is actually wrong, ETrade doesn't fill in the "Qualified Plan" column for qualified RSU plans.
+  const qualifiedIn = row["Qualified Plan"] === "Qualified" ? "fr" : "us";
+
+  // Make sure each row is valid
+  return {
+    planType: ensureDefined(planType, "planType"),
+    symbol: ensureDefined(symbol, "symbol"),
+    quantity: ensureDefined(quantity, "quantity"),
+    dateGranted: ensureDefined(dateGranted, "dateGranted"),
+    dateAcquired: ensureDefined(dateAcquired, "dateAcquired"),
+    dateSold: ensureDefined(dateSold, "dateSold"),
+    proceeds: ensureDefined(proceeds, "proceeds"),
+    adjustedCost: ensureDefined(adjustedCost, "adjustedCost"),
+    acquisitionCost: ensureDefined(acquisitionCost, "acquisitionCost"),
+    purchaseDateFairMktValue: ensureDefined(
+      purchaseDateFairMktValue,
+      "purchaseDateFairMktValue",
+    ),
+    qualifiedIn: ensureDefined(qualifiedIn, "qualifiedIn"),
+  };
+};
+
 export const parseEtradeGL = async (
   file: File,
 ): Promise<GainAndLossEvent[]> => {
@@ -21,29 +77,14 @@ export const parseEtradeGL = async (
   for (let rowIdx = 1; rowIdx < rawData.length; rowIdx++) {
     const row = rawData[rowIdx] as GainAndLossEventXlsxRow;
     try {
-      data.push({
-        planType: row["Plan Type"],
-        symbol: row["Symbol"],
-        quantity: row["Qty."],
-        proceeds: row["Proceeds Per Share"],
-        dateGranted: toDateString(row["Grant Date"]),
-        // FIXME: Adjusted cost from ETrade's G&L is the close price on day acquired,
-        // France expects the opening price on day acquired.
-        // See https://bofip.impots.gouv.fr/bofip/5654-PGP.html/identifiant%3DBOI-RSA-ES-20-20-20-20170724#:~:text=a.%20Actions%20cot%C3%A9es-,120,-La%20valeur%20%C3%A0
-        adjustedCost: row["Adjusted Cost Basis Per Share"],
-        acquisitionCost: row["Acquisition Cost Per Share"],
-        // It's unclear why this is a string and not a number.
-        purchaseDateFairMktValue: Number(row["Purchase Date Fair Mkt. Value"]),
-        dateAcquired: toDateString(row["Date Acquired"]),
-        dateSold: toDateString(row["Date Sold"]),
-        // For now consider that a non-US qualified plan is FR qualified.
-        // FIXME: this is actually wrong, ETrade doesn't fill in the "Qualified Plan" column for qualified RSU plans.
-        qualifiedIn: row["Qualified Plan"] === "Qualified" ? "us" : "fr",
-      });
-    } catch {
-      return Promise.reject(`format of file '${file.name}' is not supported`);
+      data.push(parseEtradeGLRow(row));
+    } catch (e) {
+      return Promise.reject(
+        `format of file '${file.name}' is not supported: ${e}`,
+      );
     }
   }
+
   return Promise.resolve(data);
 };
 


### PR DESCRIPTION
ETrade changed their export format, column `Qty.` was renamed to `Quantity`.

This PR fixes it.

Note that the old format is still working.