### PR TITLE
Fixes wrongly cached EUR/USD response

### DIFF
--- a/app/api/euro/[date]/route.ts
+++ b/app/api/euro/[date]/route.ts
@@ -64,6 +64,10 @@ export async function GET(
     return Response.json(exchangeRate, { status: 200 });
   } catch (error) {
     console.error(error);
+    // Invalidate the cache, just in case
+    if (CACHE_EXCHANGE_RATE_PROMISES.has(params.date)) {
+      CACHE_EXCHANGE_RATE_PROMISES.delete(params.date);
+    }
     return Response.json(
       {
         error:


### PR DESCRIPTION
We have a cached response with an error in `/api/euro/2025-11-07`

```
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:5738:19)
    at successSteps (node:internal/deps/undici/undici:5719:27)
    at fullyReadBody (node:internal/deps/undici/undici:4609:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async consumeBody (node:internal/deps/undici/undici:5728:7)
```

This PR invalidates the cache if there is an error.
