### PR TITLE
Force no cache for exchange rate fetching

### DIFF
--- a/app/api/euro/[date]/route.ts
+++ b/app/api/euro/[date]/route.ts
@@ -24,8 +24,21 @@ const baseFetchExchangeRate = async (date: string): Promise<number> => {
   url.searchParams.set("startPeriod", date);
   url.searchParams.set("endPeriod", date);
 
-  return fetch(url)
-    .then((res) => res.json())
+  // Fetch the exchange rate, with no cache to avoid having staled data
+  return fetch(url, { cache: "no-cache" })
+    .then((res) => {
+      try {
+        return res.json();
+      } catch (error) {
+        // Transform the error into a more user-friendly one
+        throw new Error(
+          `${(error as Error).message} for ${date}
+Response status: ${res.statusText} ${res.statusText}
+Response body:
+${res.text()}`,
+        );
+      }
+    })
     .then(
       (data: Response) =>
         data.dataSets[0].series["0:0:0:0:0"].observations[0][0],


### PR DESCRIPTION
There is still an issue with https://tax-helper-olive.vercel.app/api/euro/2025-11-07

This PR adds more details on the error and force a fetch with no cache...

You can try it at https://tax-helper-git-themouette-no-cache-on-41a96e-hinosxzs-projects.vercel.app/api/euro/2025-11-07 to check if it works better...