### PR TITLE
Update Etrade navigation path to include At Work step

### DIFF
--- a/app/report/_Report.tsx
+++ b/app/report/_Report.tsx
@@ -116,9 +116,9 @@ export const Report: React.FunctionComponent<ReportResidencyFrProps> = ({
           </p>
         </MessageBox>
         <div className="my-2">
-          Based on the <b>expanded</b> exports both for Gain And Losses (My
-          Account &gt; Gains and losses) and Benefit History (My Account &gt;
-          Benefit History) from Etrade.
+          Based on the <b>expanded</b> exports both for Gain And Losses (At
+          Work &gt; My Account &gt; Gains and losses) and Benefit History (At
+          Work &gt; My Account &gt; Benefit History) from Etrade.
         </div>
       </div>
       {gainsAndLosses.length === 0 ||


### PR DESCRIPTION
## Summary
- Updated the Etrade navigation instructions in the report page to include the missing "At Work" step before "My Account"
- Navigation paths now read: At Work > My Account > Gains and losses and At Work > My Account > Benefit History

## Test plan
- [ ] Visit the report page and verify the updated navigation path is displayed correctly