### PR TITLE
Add import validation table

### DIFF
--- a/app/report/_ImportValidation.tsx
+++ b/app/report/_ImportValidation.tsx
@@ -1,0 +1,134 @@
+import { Drawer } from "@/components/ui/Drawer";
+import { formatNumber } from "@/lib/format-number";
+import type { GainAndLossEventWithRates } from "@/lib/taxes/taxes-rules-fr";
+
+export const ImportValidation: React.FunctionComponent<{
+  events: GainAndLossEventWithRates[];
+}> = ({ events }) => {
+  if (events.length === 0) return null;
+
+  const totalAcqEur = events.reduce(
+    (sum, e) => sum + (e.symbolPriceAcquired / e.rateAcquired) * e.quantity,
+    0,
+  );
+  const totalSoldEur = events.reduce(
+    (sum, e) => sum + (e.proceeds / e.rateSold) * e.quantity,
+    0,
+  );
+
+  return (
+    <Drawer title={<span className="font-bold">Import Validation</span>}>
+      <div className="overflow-x-auto">
+        <table className="text-sm border-collapse w-full">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                #
+              </th>
+              <th className="border border-gray-300 px-2 py-1 whitespace-nowrap">
+                Acquisition date
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                $/stock acq.
+              </th>
+              <th className="border border-gray-300 px-2 py-1 whitespace-nowrap">
+                Sale date
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                $/stock sold
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                Qty
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                $/€ acq.
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                $/€ sold
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                €/stock acq.
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                €/stock sold
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                Total acq. €
+              </th>
+              <th className="border border-gray-300 px-2 py-1 text-right whitespace-nowrap">
+                Total sold €
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((event, i) => {
+              const eurPerStockAcq =
+                event.symbolPriceAcquired / event.rateAcquired;
+              const eurPerStockSold = event.proceeds / event.rateSold;
+              return (
+                <tr key={i} className="odd:bg-white even:bg-gray-50">
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {i + 1}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1">
+                    {event.dateAcquired}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(event.symbolPriceAcquired)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1">
+                    {event.dateSold}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(event.proceeds)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(event.quantity, 0)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(event.rateAcquired, 4)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(event.rateSold, 4)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(eurPerStockAcq)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(eurPerStockSold)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(eurPerStockAcq * event.quantity)}
+                  </td>
+                  <td className="border border-gray-300 px-2 py-1 text-right">
+                    {formatNumber(eurPerStockSold * event.quantity)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr className="bg-gray-100 font-bold">
+              <td
+                colSpan={10}
+                className="border border-gray-300 px-2 py-1 text-right"
+              >
+                Total
+              </td>
+              <td className="border border-gray-300 px-2 py-1 text-right">
+                {formatNumber(totalAcqEur)}
+              </td>
+              <td className="border border-gray-300 px-2 py-1 text-right">
+                {formatNumber(totalSoldEur)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+      <p className="text-sm text-gray-500 mt-2 px-2">
+        {events.length} operation{events.length !== 1 ? "s" : ""} found in your
+        import file (sorted by sale date).
+      </p>
+    </Drawer>
+  );
+};

--- a/app/report/_Report.tsx
+++ b/app/report/_Report.tsx
@@ -4,7 +4,12 @@ import { EtradeGainAndLossesFileInput } from "@/components/EtradeGainAndLossesFi
 import { useExchangeRates } from "@/hooks/use-fetch-exr";
 import { Button } from "@/components/ui/Button";
 import type { GainAndLossEvent } from "@/lib/etrade/etrade.types";
-import { applyFrTaxes, getEmptyTaxes } from "@/lib/taxes/taxes-rules-fr";
+import {
+  applyFrTaxes,
+  enrichEtradeGlFrFr,
+  getEmptyTaxes,
+} from "@/lib/taxes/taxes-rules-fr";
+import type { GainAndLossEventWithRates } from "@/lib/taxes/taxes-rules-fr";
 import { Section } from "@/components/ui/Section";
 import {
   isEspp,
@@ -23,6 +28,7 @@ import { sendErrorToast } from "@/components/ui/Toast";
 import { ReportFr } from "./_ReportFr";
 import type { CountryCode } from "./types";
 import { ReportUs } from "./_ReportUs";
+import { ImportValidation } from "./_ImportValidation";
 
 export interface ReportResidencyFrProps {
   taxResidency: CountryCode;
@@ -75,6 +81,23 @@ export const Report: React.FunctionComponent<ReportResidencyFrProps> = ({
     [gainsAndLosses],
   );
 
+  const enrichedEvents = useMemo<GainAndLossEventWithRates[]>(() => {
+    if (gainsAndLosses.length === 0 || isFetching || hasError || !rates)
+      return [];
+    return enrichEtradeGlFrFr(gainsAndLosses, {
+      fractions: fractionsFrIncome,
+      rates,
+      symbolPrices,
+    });
+  }, [
+    gainsAndLosses,
+    rates,
+    symbolPrices,
+    isFetching,
+    hasError,
+    fractionsFrIncome,
+  ]);
+
   const taxes = useMemo(() => {
     if (gainsAndLosses.length === 0 || isFetching || hasError || !rates) {
       return getEmptyTaxes();
@@ -116,9 +139,9 @@ export const Report: React.FunctionComponent<ReportResidencyFrProps> = ({
           </p>
         </MessageBox>
         <div className="my-2">
-          Based on the <b>expanded</b> exports both for Gain And Losses (At
-          Work &gt; My Account &gt; Gains and losses) and Benefit History (At
-          Work &gt; My Account &gt; Benefit History) from Etrade.
+          Based on the <b>expanded</b> exports both for Gain And Losses (At Work
+          &gt; My Account &gt; Gains and losses) and Benefit History (At Work
+          &gt; My Account &gt; Benefit History) from Etrade.
         </div>
       </div>
       {gainsAndLosses.length === 0 ||
@@ -195,6 +218,9 @@ export const Report: React.FunctionComponent<ReportResidencyFrProps> = ({
               </dl>
             </div>
           </Section>
+          <div className="print:hidden">
+            <ImportValidation events={enrichedEvents} />
+          </div>
           {match({ taxResidency })
             .with({ taxResidency: "fr" }, () => (
               <ReportFr

--- a/components/ui/Drawer.tsx
+++ b/components/ui/Drawer.tsx
@@ -11,7 +11,7 @@ export const Drawer: React.FunctionComponent<{
   return (
     <div>
       <div
-        className="flex items-center gap-2 cursor-pointer justify-between p-2"
+        className="flex items-center gap-2 cursor-pointer p-2"
         onClick={() => setIsOpen(!isOpen)}
       >
         <div>{title}</div>


### PR DESCRIPTION
## Summary

- Adds a collapsible **Import Validation** table below the Summary section showing all imported events with their EUR acquisition/sale values per share and per event
- Adds a **totals footer row** summing total acquisition € and total sold € across all events
- Hidden in print mode

## Test plan

- [x] Import a G&L CSV and verify the table appears with the correct number of rows
- [x] Check that the totals row sums match the per-row values
- [x] Verify the table is collapsed by default and expands on click
- [x] Verify the table is hidden when printing