### PR TITLE
Report all sales in Form 2074, including sales at a loss

### DIFF
--- a/app/report/_ReportFr.tsx
+++ b/app/report/_ReportFr.tsx
@@ -217,7 +217,7 @@ export const ReportFr = ({
           <p className="text-sm text-gray-500 mt-1">
             One operation is reported per sale. Sales at a loss report a
             negative capital gain. Form 2074 is only required when the total net
-            capital gain is positive.
+            capital gain is strictly positive.
           </p>
           <Image
             alt="Form 2074 - Page 1"

--- a/app/report/_ReportFr.tsx
+++ b/app/report/_ReportFr.tsx
@@ -1,3 +1,4 @@
+import { Drawer } from "@/components/ui/Drawer";
 import { Section } from "@/components/ui/Section";
 import type { FrTaxes } from "@/lib/taxes/taxes-rules-fr";
 import Image from "next/image";
@@ -155,7 +156,7 @@ export const ReportFr = ({
         </div>
       </Section>
       <Section title="French Taxes">
-        <div>
+        <Drawer title="Details">
           <TaxReportBox
             id="1AJ"
             title="Total income. Depending on your situation, you might use 1BJ instead. WARNING: unqualified options acquisition gain is not yet computed."
@@ -204,14 +205,19 @@ export const ReportFr = ({
             gainType="capital"
             forceOpen={isPrintMode}
           />
-        </div>
+        </Drawer>
       </Section>
       <Section title="Form 2074">
         <div>
           <p>
             You must report{" "}
-            <strong>{taxes["Form 2074"]["Page 510"].length}</strong> in this
-            form.
+            <strong>{taxes["Form 2074"]["Page 510"].length}</strong> operations
+            in this form.
+          </p>
+          <p className="text-sm text-gray-500 mt-1">
+            One operation is reported per sale. Sales at a loss report a
+            negative capital gain. Form 2074 is only required when the total net
+            capital gain is positive.
           </p>
           <Image
             alt="Form 2074 - Page 1"

--- a/lib/taxes/taxes-rules-fr.test.ts
+++ b/lib/taxes/taxes-rules-fr.test.ts
@@ -459,6 +459,59 @@ describe("getFrTaxesForFrQualifiedSo", () => {
     // (100 - 20) * 10 * 2 events = 1600
     expect(taxes["1TT"]).toEqual(1600);
   });
+
+  it("sell with gain and loss (net zero)", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        // Event A: gain of +100
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 110,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 20,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+      {
+        // Event B: loss of -100, net = 0
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 90,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 20,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-04-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedSo(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+
+    // Net capital gain is zero → Form 2074 is not filled
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+
+    // Acquisition gain is still reported
+    expect(taxes["1TT"]).toEqual(1600);
+  });
 });
 
 describe("getFrTaxesForFrQualifiedRsu()", () => {
@@ -687,6 +740,60 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
 
     // Acquisition gain: both events use symbolPriceAcquired=100, acquisitionCost=0
     // discount = (100 * 10 + 100 * 10) / 2 = 1000
+    expect(taxes["1TZ"]).toEqual(1000);
+    expect(taxes["1WZ"]).toEqual(1000);
+  });
+
+  it("sell with gain and loss (net zero)", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        // Event A: gain of +100
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 110,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 0,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+      {
+        // Event B: loss of -100, net = 0
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 90,
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 0,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-04-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedRsu(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+
+    // Net capital gain is zero → Form 2074 is not filled
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
+
+    // Acquisition gain is still reported
     expect(taxes["1TZ"]).toEqual(1000);
     expect(taxes["1WZ"]).toEqual(1000);
   });

--- a/lib/taxes/taxes-rules-fr.test.ts
+++ b/lib/taxes/taxes-rules-fr.test.ts
@@ -337,10 +337,10 @@ describe("getFrTaxesForFrQualifiedSo", () => {
     expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
 
     // Acquisition gain
-    // sellPrice = 90 / 1.13 = 79.6460176991
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
     // cost = 20 / 1.12 = 17.8571428571
-    // gain per share = 79.6460176991 - 17.8571428571 = 61.7888748419
-    expect(taxes["1TT"]).toEqual(617.88875);
+    // gain per share = 89.2857142857 - 17.8571428571 = 71.4285714286
+    expect(taxes["1TT"]).toEqual(714.28572);
   });
 
   it("sell with gains", () => {
@@ -396,6 +396,68 @@ describe("getFrTaxesForFrQualifiedSo", () => {
     expect(page510["524"].toFixed(6)).toEqual("80.000000");
     expect(page510["525"]).toEqual(false);
     expect(page510["526"]).toEqual(0);
+  });
+
+  it("sell with gain and loss (net positive)", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        // Event A: gain
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 120, // Sold at 120$ when acquired at 100$
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 20,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+      {
+        // Event B: loss
+        symbol: "DDOG",
+        planType: "SO",
+        quantity: 10,
+        proceeds: 90, // Sold at 90$ when acquired at 100$
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 20,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-04-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedSo(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+
+    // Both operations appear in Form 2074
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(2);
+
+    // Net capital gain is positive (200 - 100 = 100)
+    expect(taxes["3VG"]).toEqual(100);
+
+    // Loss event has a negative cell 524
+    const gainPage = taxes["Form 2074"]["Page 510"][0];
+    const lossPage = taxes["Form 2074"]["Page 510"][1];
+    expect(gainPage["524"]).toEqual(200);
+    expect(lossPage["524"]).toEqual(-100);
+
+    // Acquisition gain: both events use symbolPriceAcquired=100
+    // (100 - 20) * 10 * 2 events = 1600
+    expect(taxes["1TT"]).toEqual(1600);
   });
 });
 
@@ -466,11 +528,11 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
     expect(taxes["3VG"]).toEqual(0);
     expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
     // Acquisition gain
-    // sellPrice = 90 / 1.13 = 79.6460176991
-    // discount = 79.6460176991 / 2 = 39.8230088495
-    expect(taxes["1TZ"]).toEqual(398.230085);
+    // acquisitionValue = 100 / 1.12 = 89.2857142857
+    // discount = 89.2857142857 / 2 = 44.6428571429
+    expect(taxes["1TZ"]).toEqual(446.42857);
     expect(taxes["1TT"]).toEqual(0);
-    expect(taxes["1WZ"]).toEqual(398.230085);
+    expect(taxes["1WZ"]).toEqual(446.42857);
   });
 
   it("sell with gains", () => {
@@ -565,6 +627,69 @@ describe("getFrTaxesForFrQualifiedRsu()", () => {
     expect(taxes["1TT"]).toEqual(0);
     expect(taxes["1WZ"]).toEqual(401.785713);
   });
+
+  it("sell with gain and loss (net positive)", () => {
+    const gainsAndLosses: GainAndLossEventWithRates[] = [
+      {
+        // Event A: gain
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 120, // Sold at 120$ when acquired at 100$
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 0,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-03-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+      {
+        // Event B: loss
+        symbol: "DDOG",
+        planType: "RS",
+        quantity: 10,
+        proceeds: 90, // Sold at 90$ when acquired at 100$
+        adjustedCost: 80,
+        purchaseDateFairMktValue: 80,
+        acquisitionCost: 0,
+        dateGranted: "2021-03-03",
+        dateAcquired: "2022-03-03",
+        dateSold: "2022-04-09",
+        qualifiedIn: "fr",
+        rateAcquired: 1,
+        rateSold: 1,
+        symbolPriceAcquired: 100,
+        fractionFrIncome: 1,
+      },
+    ];
+
+    const taxes = getFrTaxesForFrQualifiedRsu(
+      { gainsAndLosses },
+      getEmptyTaxes(),
+    );
+
+    // Both operations appear in Form 2074
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(2);
+
+    // Net capital gain is positive (200 - 100 = 100)
+    expect(taxes["3VG"]).toEqual(100);
+
+    // Loss event has a negative cell 524
+    const gainPage = taxes["Form 2074"]["Page 510"][0];
+    const lossPage = taxes["Form 2074"]["Page 510"][1];
+    expect(gainPage["524"]).toEqual(200);
+    expect(lossPage["524"]).toEqual(-100);
+
+    // Acquisition gain: both events use symbolPriceAcquired=100, acquisitionCost=0
+    // discount = (100 * 10 + 100 * 10) / 2 = 1000
+    expect(taxes["1TZ"]).toEqual(1000);
+    expect(taxes["1WZ"]).toEqual(1000);
+  });
 });
 
 describe("getFrTaxesForEspp", () => {
@@ -590,27 +715,12 @@ describe("getFrTaxesForEspp", () => {
     ];
 
     const taxes = getFrTaxesForEspp({ gainsAndLosses }, getEmptyTaxes());
-    // Capital loss
+    // Net capital loss → Form 2074 is not filled
     // acquisitionValue = 100 / 1.12 = 89.2857142857
     // sellPrice = 90 / 1.13 = 79.6460176991
     // capital loss = 79.6460176991 - 89.2857142857 = -9.6396965866
-    expect(taxes["3VG"].toFixed(6)).toEqual("-97.000000");
-    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
-    const page510 = taxes["Form 2074"]["Page 510"][0];
-    expect(page510["511"]).toEqual("DDOG (ESPP)");
-    expect(page510["512"]).toEqual("09/03/2022");
-    expect(page510["514"].toFixed(6)).toEqual("79.646017");
-    expect(page510["515"]).toEqual(10);
-    expect(page510["516"].toFixed(6)).toEqual("796.000000");
-    expect(page510["517"]).toEqual(0);
-    expect(page510["518"].toFixed(6)).toEqual("796.000000");
-    expect(page510["520"].toFixed(6)).toEqual("89.290000");
-    expect(page510["521"].toFixed(6)).toEqual("893.000000");
-    expect(page510["522"]).toEqual(0);
-    expect(page510["523"].toFixed(6)).toEqual("893.000000");
-    expect(page510["524"].toFixed(6)).toEqual("-97.000000");
-    expect(page510["525"]).toEqual(false);
-    expect(page510["526"]).toEqual(0);
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
     // Acquisition gain
     expect(taxes["1AJ"]).toEqual(0);
     expect(taxes["1TZ"]).toEqual(0);
@@ -692,27 +802,12 @@ describe("getFrTaxesForEspp", () => {
     ];
 
     const taxes = getFrTaxesForEspp({ gainsAndLosses }, getEmptyTaxes());
-    // Capital loss
+    // Net capital loss → Form 2074 is not filled
     // acquisitionValue = 100 / 1.12 = 89.2857142857
     // sellPrice = 90 / 1.13 = 79.6460176991
     // capital loss = 79.6460176991 - 89.2857142857 = -9.6396965866
-    expect(taxes["3VG"].toFixed(6)).toEqual("-97.000000");
-    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
-    const page510 = taxes["Form 2074"]["Page 510"][0];
-    expect(page510["511"]).toEqual("DDOG (ESPP)");
-    expect(page510["512"]).toEqual("09/03/2022");
-    expect(page510["514"].toFixed(6)).toEqual("79.646017");
-    expect(page510["515"]).toEqual(10);
-    expect(page510["516"].toFixed(6)).toEqual("796.000000");
-    expect(page510["517"]).toEqual(0);
-    expect(page510["518"].toFixed(6)).toEqual("796.000000");
-    expect(page510["520"].toFixed(6)).toEqual("89.290000");
-    expect(page510["521"].toFixed(6)).toEqual("893.000000");
-    expect(page510["522"]).toEqual(0);
-    expect(page510["523"].toFixed(6)).toEqual("893.000000");
-    expect(page510["524"].toFixed(6)).toEqual("-97.000000");
-    expect(page510["525"]).toEqual(false);
-    expect(page510["526"]).toEqual(0);
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
     // Acquisition gain
     expect(taxes["1AJ"]).toEqual(0);
     expect(taxes["1TZ"]).toEqual(0);
@@ -774,27 +869,12 @@ describe("getFrTaxesForNonFrQualifiedSo", () => {
       { gainsAndLosses, benefits: [] },
       getEmptyTaxes(),
     );
-    // Capital loss
+    // Net capital loss → Form 2074 is not filled
     // acquisitionValue = 100 / 1.12 = 89.2857142857
     // sellPrice = 90 / 1.13 = 79.6460176991
     // capital loss = 79.6460176991 - 89.2857142857 = -9.6396965866
-    expect(taxes["3VG"].toFixed(6)).toEqual("-97.000000");
-    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
-    const page510 = taxes["Form 2074"]["Page 510"][0];
-    expect(page510["511"]).toEqual("DDOG (Stock Options)");
-    expect(page510["512"]).toEqual("09/03/2022");
-    expect(page510["514"].toFixed(6)).toEqual("79.646017");
-    expect(page510["515"]).toEqual(10);
-    expect(page510["516"].toFixed(6)).toEqual("796.000000");
-    expect(page510["517"]).toEqual(0);
-    expect(page510["518"].toFixed(6)).toEqual("796.000000");
-    expect(page510["520"].toFixed(6)).toEqual("89.290000");
-    expect(page510["521"].toFixed(6)).toEqual("893.000000");
-    expect(page510["522"]).toEqual(0);
-    expect(page510["523"].toFixed(6)).toEqual("893.000000");
-    expect(page510["524"].toFixed(6)).toEqual("-97.000000");
-    expect(page510["525"]).toEqual(false);
-    expect(page510["526"]).toEqual(0);
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
   });
   it("capital gain", () => {
     const gainsAndLosses: GainAndLossEventWithRates[] = [
@@ -897,27 +977,12 @@ describe("getFrTaxesForNonFrQualifiedRsu", () => {
       { gainsAndLosses, benefits: [] },
       getEmptyTaxes(),
     );
-    // Capital loss
+    // Net capital loss → Form 2074 is not filled
     // acquisitionValue = 100 / 1.12 = 89.2857142857
     // sellPrice = 90 / 1.13 = 79.6460176991
     // capital loss = 79.6460176991 - 89.2857142857 = -9.6396965866
-    expect(taxes["3VG"].toFixed(6)).toEqual("-97.000000");
-    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(1);
-    const page510 = taxes["Form 2074"]["Page 510"][0];
-    expect(page510["511"]).toEqual("DDOG (RSU)");
-    expect(page510["512"]).toEqual("09/03/2022");
-    expect(page510["514"].toFixed(6)).toEqual("79.646017");
-    expect(page510["515"]).toEqual(10);
-    expect(page510["516"].toFixed(6)).toEqual("796.000000");
-    expect(page510["517"]).toEqual(0);
-    expect(page510["518"].toFixed(6)).toEqual("796.000000");
-    expect(page510["520"].toFixed(6)).toEqual("89.290000");
-    expect(page510["521"].toFixed(6)).toEqual("893.000000");
-    expect(page510["522"]).toEqual(0);
-    expect(page510["523"].toFixed(6)).toEqual("893.000000");
-    expect(page510["524"].toFixed(6)).toEqual("-97.000000");
-    expect(page510["525"]).toEqual(false);
-    expect(page510["526"]).toEqual(0);
+    expect(taxes["3VG"]).toEqual(0);
+    expect(taxes["Form 2074"]["Page 510"]).toHaveLength(0);
   });
   it("capital gain", () => {
     const gainsAndLosses: GainAndLossEventWithRates[] = [

--- a/lib/taxes/taxes-rules-fr.ts
+++ b/lib/taxes/taxes-rules-fr.ts
@@ -362,8 +362,8 @@ const getFrTaxesCapitalGain = (
     newPages.push(newPage);
   });
 
-  // Net loss → do not fill Form 2074
-  if (capitalGainEur < 0) {
+  // Net loss or zero → do not fill Form 2074
+  if (capitalGainEur <= 0) {
     return taxes;
   }
 

--- a/lib/taxes/taxes-rules-fr.ts
+++ b/lib/taxes/taxes-rules-fr.ts
@@ -307,10 +307,6 @@ const getFrTaxesCapitalGain = (
   if (!taxableEvents.length) {
     return taxes;
   }
-  if (taxableEvents.every((event) => event.capitalGain.total === 0)) {
-    return taxes;
-  }
-
   let capitalGainEur = 0;
   const newPages: FrTaxes["Form 2074"]["Page 510"] = [];
 
@@ -365,6 +361,11 @@ const getFrTaxesCapitalGain = (
     capitalGainEur += newPage["524"];
     newPages.push(newPage);
   });
+
+  // Net loss → do not fill Form 2074
+  if (capitalGainEur < 0) {
+    return taxes;
+  }
 
   // Add the capital gain to the total
   taxes["3VG"] += capitalGainEur;
@@ -487,14 +488,7 @@ export const getFrTaxesForFrQualifiedSo = (
 
   // Process each event
   qualifiedSo.forEach((event) => {
-    // Convert prices to EUR
-    const sellPriceEur = floorNumber6Digits(event.proceeds / event.rateSold);
-    const priceOnDayOfAcquisitionEur = floorNumber6Digits(
-      event.symbolPriceAcquired / event.rateAcquired,
-    );
-
     const isSellToCover = event.dateAcquired === event.dateSold;
-    const isSellAtLoss = sellPriceEur < priceOnDayOfAcquisitionEur;
 
     const taxableEvent = getFrTaxableEventFromGainsAndLossEvent(
       event,
@@ -508,23 +502,13 @@ export const getFrTaxesForFrQualifiedSo = (
             explainAcquisitionValue:
               "Use sell price as acquisition value given this is a sell to cover.",
           }
-        : isSellAtLoss
-          ? {
-              // Sale is at loss, use sell price as acquisition price given the
-              // plan is qualified
-              acquisitionValueUsd: event.proceeds,
-              acquisitionValueRate: event.rateSold,
-              acquisitionCostUsd: event.acquisitionCost,
-              explainAcquisitionValue:
-                "Acquisition value is the sell price given the plan is qualified and the sale is at loss.",
-            }
-          : {
-              // Just use symbol price at opening the day of exercise.
-              acquisitionValueUsd: event.symbolPriceAcquired,
-              acquisitionValueRate: event.rateAcquired,
-              acquisitionCostUsd: event.acquisitionCost,
-              explainAcquisitionValue: `Use ${event.symbol} price at opening on day of exercise.`,
-            },
+        : {
+            // Just use symbol price at opening the day of exercise.
+            acquisitionValueUsd: event.symbolPriceAcquired,
+            acquisitionValueRate: event.rateAcquired,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue: `Use ${event.symbol} price at opening on day of exercise.`,
+          },
     );
     taxableEvents.push(taxableEvent);
 
@@ -569,13 +553,7 @@ export const getFrTaxesForFrQualifiedRsu = (
 
   // Process each event
   qualifiedRsu.forEach((event) => {
-    // Convert prices to EUR
-    const sellPriceEur = floorNumber6Digits(event.proceeds / event.rateSold);
-    const priceOnDayOfAcquisitionEur = floorNumber6Digits(
-      event.symbolPriceAcquired / event.rateAcquired,
-    );
     const isSellToCover = event.dateAcquired === event.dateSold;
-    const isSellAtLoss = sellPriceEur < priceOnDayOfAcquisitionEur;
 
     const taxableEvent = getFrTaxableEventFromGainsAndLossEvent(
       event,
@@ -594,23 +572,13 @@ export const getFrTaxesForFrQualifiedRsu = (
               "If you encouter this message, please contact French taxes support.",
             ].join("\n"),
           }
-        : isSellAtLoss
-          ? {
-              // Sale is at loss, use sell price as acquisition price given this
-              // is a qualified plan
-              acquisitionValueUsd: event.proceeds,
-              acquisitionValueRate: event.rateSold,
-              acquisitionCostUsd: event.acquisitionCost,
-              explainAcquisitionValue:
-                "Acquisition value is the sell price given the plan is qualified and the sale is at loss.",
-            }
-          : {
-              // Just use symbol price at opening the vesting day.
-              acquisitionValueUsd: event.symbolPriceAcquired,
-              acquisitionValueRate: event.rateAcquired,
-              acquisitionCostUsd: event.acquisitionCost,
-              explainAcquisitionValue: `Use ${event.symbol} price at opening on vesting day.`,
-            },
+        : {
+            // Just use symbol price at opening the vesting day.
+            acquisitionValueUsd: event.symbolPriceAcquired,
+            acquisitionValueRate: event.rateAcquired,
+            acquisitionCostUsd: event.acquisitionCost,
+            explainAcquisitionValue: `Use ${event.symbol} price at opening on vesting day.`,
+          },
     );
 
     taxableEvents.push(taxableEvent);


### PR DESCRIPTION
## Summary

- **Fix acquisition value for sell-at-loss events**: removes the `isSellAtLoss` branch in `getFrTaxesForFrQualifiedSo` and `getFrTaxesForFrQualifiedRsu` that incorrectly used the sell price as acquisition value — loss events now correctly use `symbolPriceAcquired`, giving the right 1TT / 1TZ values
- **Net-total gate for Form 2074**: `getFrTaxesCapitalGain` now only populates Form 2074 when the net capital gain is **strictly positive** (> 0); a net loss or net zero no longer fills the form, but mixed batches (some gains, some losses) with a net gain are fully reported with negative cell 524 for loss rows
- **Explanation note**: adds a helper text in the Form 2074 section explaining that loss sales show a negative capital gain and that the form is only required when the net total is strictly positive

## Test plan

- [ ] Import FR qualified SO/RSU sales with only losses → 3VG = 0, Form 2074 shows 0 operations
- [ ] Import FR qualified SO/RSU sales where gains and losses cancel out (net = 0) → 3VG = 0, Form 2074 shows 0 operations
- [ ] Import FR qualified SO/RSU sales with a mix of gains and losses (net positive) → all operations appear in Form 2074, loss rows have negative cell 524
- [ ] Verify 1TT / 1TZ values for loss-only events use the symbolPriceAcquired (not the sell price)
- [ ] Run `npx jest taxes-rules-fr.test.ts` — all 25 tests pass