### PR TITLE
Add banner to inform about number of gains to declare < imported sales

### DIFF
--- a/app/report/_Report.tsx
+++ b/app/report/_Report.tsx
@@ -227,6 +227,7 @@ export const Report: React.FunctionComponent<ReportResidencyFrProps> = ({
                 hasSoldShares={gainsAndLosses.length > 0}
                 isPrintMode={isPrintMode}
                 taxes={taxes}
+                importedEventsCount={enrichedEvents.length}
               />
             ))
             .with({ taxResidency: "us" }, () => (

--- a/app/report/_ReportFr.tsx
+++ b/app/report/_ReportFr.tsx
@@ -2,6 +2,7 @@ import { Section } from "@/components/ui/Section";
 import type { FrTaxes } from "@/lib/taxes/taxes-rules-fr";
 import Image from "next/image";
 import { Link } from "@/components/ui/Link";
+import { MessageBox } from "@/components/ui/MessageBox";
 import { TaxReportBox } from "./_TaxReportBox";
 import { Currency } from "@/components/ui/Currency";
 import { Button } from "@/components/ui/Button";
@@ -10,6 +11,7 @@ import { match } from "ts-pattern";
 import {
   ChevronDoubleLeftIcon,
   ChevronDoubleRightIcon,
+  InformationCircleIcon,
 } from "@heroicons/react/24/solid";
 import { useState } from "react";
 import { CopyableCell } from "./_CopyableCell";
@@ -18,13 +20,16 @@ interface ReportResidencyFrContentProps {
   hasSoldShares: boolean;
   isPrintMode: boolean;
   taxes: FrTaxes;
+  importedEventsCount: number;
 }
 
 export const ReportFr = ({
   hasSoldShares,
   isPrintMode,
   taxes,
+  importedEventsCount,
 }: ReportResidencyFrContentProps) => {
+  const declaredCount = taxes["Form 2074"]["Page 510"].length;
   return (
     <>
       <Section title="Select Income Source and Annexes">
@@ -206,12 +211,66 @@ export const ReportFr = ({
           />
         </div>
       </Section>
+      {isPrintMode ? null : (
+        <div className="print:hidden">
+          <MessageBox
+            level="info"
+            title={
+              <span className="inline-flex items-center gap-1">
+                <InformationCircleIcon className="h-5 w-5" />
+                Why are some sales not shown?
+              </span>
+            }
+          >
+            <p>
+              <strong>{declaredCount}</strong> of{" "}
+              <strong>{importedEventsCount}</strong> imported sale
+              {importedEventsCount !== 1 ? "s" : ""} should be declared in Form
+              2074.
+            </p>
+            <p className="mt-2">
+              Sales at a loss are handled differently depending on the type of
+              equity:
+            </p>
+            <ul className="list-disc pl-6 mt-2">
+              <li>
+                <strong>RSU sales at a loss</strong> are intentionally excluded.
+                Under French tax law (
+                <Link
+                  href="https://bofip.impots.gouv.fr/bofip/5654-PGP.html/identifiant%3DBOI-RSA-ES-20-20-20-20170724"
+                  isExternal
+                >
+                  BOI-RSA-ES-20-20-20
+                </Link>
+                ), any loss on RSU shares is deducted directly from the
+                acquisition gain — so there is no separate loss to declare in
+                Form 2074.
+              </li>
+              <li>
+                <strong>ESPP sales at a loss</strong> follow different rules and
+                may still appear.
+              </li>
+              <li>
+                <strong>
+                  USD gains that become losses after EUR conversion
+                </strong>{" "}
+                are also excluded. The exchange rates on the acquisition date
+                and sale date differ, so a gain in USD can turn into a loss in
+                EUR.
+              </li>
+            </ul>
+            <p className="mt-2">
+              If the number of transactions shown seems lower than expected,
+              check whether the missing sales fall into one of the categories
+              above by expanding the import validation section above.
+            </p>
+          </MessageBox>
+        </div>
+      )}
       <Section title="Form 2074">
         <div>
           <p>
-            You must report{" "}
-            <strong>{taxes["Form 2074"]["Page 510"].length}</strong> in this
-            form.
+            You must report <strong>{declaredCount}</strong> in this form.
           </p>
           <Image
             alt="Form 2074 - Page 1"

--- a/components/ui/MessageBox.tsx
+++ b/components/ui/MessageBox.tsx
@@ -1,6 +1,6 @@
 export interface MessageBoxProps {
   level: "info" | "success" | "warning" | "error";
-  title: string;
+  title: React.ReactNode;
   children?: React.ReactNode;
 }
 


### PR DESCRIPTION
## Summary

Adds an info banner above the **Form 2074** section in the French tax report explaining why the number of declared sales may be lower than the number of imported sales.

The banner is hidden in print mode and shown only in the on-screen flow.

## What it shows

- A dynamic count: **X of Y imported sales should be declared in Form 2074.**
- The three reasons a sale may be excluded:
  - **RSU sales at a loss** — intentionally excluded per [BOI-RSA-ES-20-20-20](https://bofip.impots.gouv.fr/bofip/5654-PGP.html/identifiant%3DBOI-RSA-ES-20-20-20-20170724); the loss is deducted from the acquisition gain, not declared separately.
  - **ESPP sales at a loss** — follow different rules and may still appear.
  - **USD gains turning into EUR losses** — excluded due to acquisition/sale-date FX rate divergence.
- A pointer to the **Import Validation** drawer above for users to verify which transactions were dropped.

## Implementation notes

- `MessageBox` `title` widened from `string` to `React.ReactNode` so the banner title can carry an info icon next to the heading text. Existing string callers are unaffected.
- `ReportFr` now takes an `importedEventsCount` prop (`enrichedEvents.length`), threaded through from `_Report.tsx`.
- Declared count is read from `taxes["Form 2074"]["Page 510"].length`.

## Screenshot

<img width="1671" height="968" alt="image" src="https://github.com/user-attachments/assets/caa7e0e7-748e-414c-ac54-09771deacb28" />