### PR TITLE
address some slack feedbacks

### DIFF
--- a/app/report/_Report.tsx
+++ b/app/report/_Report.tsx
@@ -140,8 +140,7 @@ export const Report: React.FunctionComponent<ReportResidencyFrProps> = ({
         </MessageBox>
         <div className="my-2">
           Based on the <b>expanded</b> exports both for Gain And Losses (At Work
-          &gt; My Account &gt; Gains and losses) and Benefit History (At Work
-          &gt; My Account &gt; Benefit History) from Etrade.
+          &gt; My Account &gt; Gains and losses) from Etrade.
         </div>
       </div>
       {gainsAndLosses.length === 0 ||

--- a/app/report/_ReportFr.tsx
+++ b/app/report/_ReportFr.tsx
@@ -228,32 +228,12 @@ export const ReportFr = ({
           <Page510 taxes={taxes} isPrintMode={isPrintMode} />
         </div>
         <QualifiedAtLossSection taxes={taxes} isPrintMode={isPrintMode} />
-        {isPrintMode ? null : (
-          <div className="print:hidden mt-6">
-            <div className="text-lg font-bold my-auto mb-2">
-              One Last Step For Form 2074
-            </div>
-            {taxes["Form 2074"]["page 11"]["1133"].losses > 0 ? (
-              <>
-                <p>
-                  You must report{" "}
-                  <strong>
-                    <Currency
-                      unit="eur"
-                      value={taxes["Form 2074"]["page 11"]["1133"].gains}
-                    />
-                  </strong>{" "}
-                  (capital gains) and{" "}
-                  <strong>
-                    <Currency
-                      unit="eur"
-                      value={taxes["Form 2074"]["page 11"]["1133"].losses}
-                    />
-                  </strong>{" "}
-                  (capital losses) on line <strong>1133</strong>.
-                </p>
-              </>
-            ) : (
+        <div className="mt-6">
+          <div className="text-lg font-bold my-auto mb-2">
+            One Last Step For Form 2074
+          </div>
+          {taxes["Form 2074"]["page 11"]["1133"].losses > 0 ? (
+            <>
               <p>
                 You must report{" "}
                 <strong>
@@ -262,22 +242,40 @@ export const ReportFr = ({
                     value={taxes["Form 2074"]["page 11"]["1133"].gains}
                   />
                 </strong>{" "}
-                on line <strong>1133</strong>.
+                (capital gains) and{" "}
+                <strong>
+                  <Currency
+                    unit="eur"
+                    value={taxes["Form 2074"]["page 11"]["1133"].losses}
+                  />
+                </strong>{" "}
+                (capital losses) on line <strong>1133</strong>.
               </p>
-            )}
-            <Image
-              src={
-                taxes["Form 2074"]["page 11"]["1133"].losses > 0
-                  ? "/images/fr-taxes/form-2074-1133-with-losses.png"
-                  : "/images/fr-taxes/form-2074-box-1133.png"
-              }
-              alt="Form 2074 - Box 1133"
-              width={800}
-              height={500}
-              className="print:hidden"
-            />
-          </div>
-        )}
+            </>
+          ) : (
+            <p>
+              You must report{" "}
+              <strong>
+                <Currency
+                  unit="eur"
+                  value={taxes["Form 2074"]["page 11"]["1133"].gains}
+                />
+              </strong>{" "}
+              on line <strong>1133</strong>.
+            </p>
+          )}
+          <Image
+            src={
+              taxes["Form 2074"]["page 11"]["1133"].losses > 0
+                ? "/images/fr-taxes/form-2074-1133-with-losses.png"
+                : "/images/fr-taxes/form-2074-box-1133.png"
+            }
+            alt="Form 2074 - Box 1133"
+            width={800}
+            height={500}
+            className="print:hidden"
+          />
+        </div>
       </Section>
     </>
   );


### PR DESCRIPTION
Feedback on the tax helper: (I may open PRs later, but feel free to do it if you want)

- Can we stop mentioning the export of Benefit History from E-Trade since it's not used by the tool?
- "One Last Step For Form 2074" doesn't show with print mode enabled, so I almost forgot to fill 1133 / Titres A after Form 2074. And it's not showing either when printing with print mode disabled :thinking_face: Is that voluntary?