### PR TITLE
Group G&L entries by lot key and sum quantities

### DIFF
--- a/lib/etrade/parse-etrade-gl.test.ts
+++ b/lib/etrade/parse-etrade-gl.test.ts
@@ -2,7 +2,8 @@
  * @jest-environment node
  */
 import XLSX from "xlsx";
-import { parseEtradeGL } from "./parse-etrade-gl";
+import { groupEtradeGL, parseEtradeGL } from "./parse-etrade-gl";
+import type { GainAndLossEvent } from "./etrade.types";
 
 function buildXlsx(headers: string[], dataRows: unknown[][]): File {
   const summaryRow = new Array(headers.length).fill("");
@@ -144,5 +145,80 @@ describe("parseEtradeGL", () => {
       ],
     ]);
     await expect(parseEtradeGL(file)).rejects.toMatch("is not supported");
+  });
+});
+
+const baseEvent: GainAndLossEvent = {
+  planType: "RS",
+  symbol: "DDOG",
+  quantity: 10,
+  dateGranted: "2021-06-01",
+  dateAcquired: "2023-03-01",
+  dateSold: "2023-06-15",
+  proceeds: 95,
+  adjustedCost: 80,
+  acquisitionCost: 0,
+  purchaseDateFairMktValue: 0,
+  qualifiedIn: "fr",
+};
+
+describe("groupEtradeGL", () => {
+  it("returns a single entry when all fields match", () => {
+    const events: GainAndLossEvent[] = [
+      { ...baseEvent, quantity: 10 },
+      { ...baseEvent, quantity: 5 },
+    ];
+    const result = groupEtradeGL(events);
+    expect(result).toHaveLength(1);
+    expect(result[0].quantity).toBe(15);
+  });
+
+  it("keeps entries separate when grant date differs", () => {
+    const events: GainAndLossEvent[] = [
+      { ...baseEvent, dateGranted: "2021-06-01" },
+      { ...baseEvent, dateGranted: "2022-06-01" },
+    ];
+    expect(groupEtradeGL(events)).toHaveLength(2);
+  });
+
+  it("keeps entries separate when vest date differs", () => {
+    const events: GainAndLossEvent[] = [
+      { ...baseEvent, dateAcquired: "2023-03-01" },
+      { ...baseEvent, dateAcquired: "2023-06-01" },
+    ];
+    expect(groupEtradeGL(events)).toHaveLength(2);
+  });
+
+  it("keeps entries separate when sell date differs", () => {
+    const events: GainAndLossEvent[] = [
+      { ...baseEvent, dateSold: "2023-06-15" },
+      { ...baseEvent, dateSold: "2023-07-01" },
+    ];
+    expect(groupEtradeGL(events)).toHaveLength(2);
+  });
+
+  it("keeps entries separate when sell price differs", () => {
+    const events: GainAndLossEvent[] = [
+      { ...baseEvent, proceeds: 95 },
+      { ...baseEvent, proceeds: 100 },
+    ];
+    expect(groupEtradeGL(events)).toHaveLength(2);
+  });
+
+  it("keeps entries separate when plan type differs", () => {
+    const events: GainAndLossEvent[] = [
+      { ...baseEvent, planType: "RS" },
+      { ...baseEvent, planType: "SO" },
+    ];
+    expect(groupEtradeGL(events)).toHaveLength(2);
+  });
+
+  it("preserves all other fields from the first entry in the group", () => {
+    const events: GainAndLossEvent[] = [
+      { ...baseEvent, quantity: 10 },
+      { ...baseEvent, quantity: 5 },
+    ];
+    const result = groupEtradeGL(events);
+    expect(result[0]).toEqual({ ...baseEvent, quantity: 15 });
   });
 });

--- a/lib/etrade/parse-etrade-gl.ts
+++ b/lib/etrade/parse-etrade-gl.ts
@@ -85,7 +85,26 @@ export const parseEtradeGL = async (
     }
   }
 
-  return Promise.resolve(data);
+  return Promise.resolve(groupEtradeGL(data));
+};
+
+/**
+ * Group G&L entries by grant date, vest date, sell date, and sell price.
+ * Entries sharing the same key are merged by summing their quantities.
+ */
+export const groupEtradeGL = (
+  events: GainAndLossEvent[],
+): GainAndLossEvent[] => {
+  const groups = Map.groupBy(
+    events,
+    (event) =>
+      `${event.planType}|${event.symbol}|${event.dateGranted}|${event.dateAcquired}|${event.dateSold}|${event.proceeds}`,
+  );
+
+  return Array.from(groups.values()).map((group) => ({
+    ...group[0],
+    quantity: group.reduce((sum, event) => sum + event.quantity, 0),
+  }));
 };
 
 /**


### PR DESCRIPTION
As suggested by Clément on Slack

<img width="509" height="735" alt="image" src="https://github.com/user-attachments/assets/f82405ad-726f-48d8-b63c-b1911a441471" />
