### PR TITLE
Add CEHR smoothing calculator (système du quotient)

### DIFF
--- a/app/cehr/_AssetTypeSelector.tsx
+++ b/app/cehr/_AssetTypeSelector.tsx
@@ -1,0 +1,52 @@
+import classNames from "classnames";
+import { Section } from "@/components/ui/Section";
+import { ASSET_DEFINITIONS, type AssetType } from "@/lib/taxes/cehr-template";
+
+interface Props {
+  assetTypes: AssetType[];
+  onToggle: (id: AssetType) => void;
+}
+
+export const AssetTypeSelector = ({ assetTypes, onToggle }: Props) => (
+  <Section title="Type de revenus exceptionnels concernés">
+    <p className="text-sm text-gray-600 mb-3">
+      Cochez les natures de revenus exceptionnels à mentionner dans le courrier.
+      Le texte d&apos;introduction et la liste des justificatifs
+      s&apos;adapteront automatiquement.
+    </p>
+    <div className="flex flex-col gap-2 max-w-3xl">
+      {Object.values(ASSET_DEFINITIONS).map((asset) => {
+        const checked = assetTypes.includes(asset.id);
+        return (
+          <label
+            key={asset.id}
+            className={classNames(
+              "flex items-start gap-3 p-3 rounded-md border cursor-pointer",
+              checked
+                ? "border-blue-300 bg-blue-50"
+                : "border-gray-200 hover:border-gray-300",
+            )}
+          >
+            <input
+              type="checkbox"
+              checked={checked}
+              onChange={() => onToggle(asset.id)}
+              className="mt-0.5"
+            />
+            <div className="text-sm">
+              <div className="font-medium">{asset.label}</div>
+              <div className="text-xs text-gray-600 mt-0.5">
+                Justificatifs : {asset.justificatifs.join(" · ")}
+              </div>
+            </div>
+          </label>
+        );
+      })}
+    </div>
+    {assetTypes.length === 0 && (
+      <div className="mt-3 p-3 rounded-md bg-yellow-50 border border-yellow-200 text-sm text-yellow-900">
+        Cochez au moins un type de revenu exceptionnel pour générer le courrier.
+      </div>
+    )}
+  </Section>
+);

--- a/app/cehr/_CehrComparisonTable.tsx
+++ b/app/cehr/_CehrComparisonTable.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import classNames from "classnames";
+import { useState, type ReactNode } from "react";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
 import { Section } from "@/components/ui/Section";
 import {
@@ -17,6 +16,23 @@ interface Props {
   midpointBreakdown: CehrBreakdown;
 }
 
+interface ComparisonRow {
+  label: ReactNode;
+  withoutQuotient: number;
+  withQuotient: number;
+  showQuotientMultiplier?: boolean;
+}
+
+const QuotientMultiplierBadge = () => (
+  <span
+    className="ml-1 text-xs font-semibold text-green-700"
+    title="Montant doublé par le mécanisme du quotient"
+    aria-label="montant doublé par le mécanisme du quotient"
+  >
+    quotient ×2
+  </span>
+);
+
 export const CehrComparisonTable = ({
   result,
   rfrN,
@@ -26,6 +42,61 @@ export const CehrComparisonTable = ({
   midpointBreakdown,
 }: Props) => {
   const [showSteps, setShowSteps] = useState(false);
+  const excess = rfrN - result.averagePrevious;
+  const halfExcess = excess / 2;
+  const rows: ComparisonRow[] = [
+    {
+      label: "Base 3 %",
+      withoutQuotient: result.cehrWithoutQuotient.base3,
+      withQuotient: midpointBreakdown.base3,
+    },
+    {
+      label: "Base 4 %",
+      withoutQuotient: result.cehrWithoutQuotient.base4,
+      withQuotient: midpointBreakdown.base4,
+    },
+    {
+      label: "CEHR à 3 %",
+      withoutQuotient: result.cehrWithoutQuotient.amount3,
+      withQuotient: midpointBreakdown.amount3 * 2,
+      showQuotientMultiplier: true,
+    },
+    {
+      label: "CEHR à 4 %",
+      withoutQuotient: result.cehrWithoutQuotient.amount4,
+      withQuotient: midpointBreakdown.amount4 * 2,
+      showQuotientMultiplier: true,
+    },
+  ];
+  const steps: ReactNode[] = [
+    <>
+      Moyenne des deux années précédentes :{" "}
+      <span className="font-mono">
+        ({fmtEur(rfrNm2)} + {fmtEur(rfrNm1)}) / 2 ={" "}
+        <strong>{fmtEur(result.averagePrevious)}</strong>
+      </span>
+    </>,
+    <>
+      Fraction excédentaire :{" "}
+      <span className="font-mono">
+        {fmtEur(rfrN)} − {fmtEur(result.averagePrevious)} ={" "}
+        <strong>{fmtEur(excess)}</strong>
+      </span>
+    </>,
+    <>
+      Fraction divisée par deux :{" "}
+      <span className="font-mono">
+        {fmtEur(excess)} / 2 = <strong>{fmtEur(halfExcess)}</strong>
+      </span>
+    </>,
+    <>
+      Base lissée :{" "}
+      <span className="font-mono">
+        {fmtEur(result.averagePrevious)} + {fmtEur(halfExcess)} ={" "}
+        <strong className="text-green-700">{fmtEur(midpoint)}</strong>
+      </span>
+    </>,
+  ];
 
   return (
     <Section title="Comparaison du calcul CEHR">
@@ -46,10 +117,7 @@ export const CehrComparisonTable = ({
                 <button
                   type="button"
                   onClick={() => setShowSteps((s) => !s)}
-                  className={classNames(
-                    "flex items-center gap-1",
-                    "hover:text-gray-900 cursor-pointer",
-                  )}
+                  className="flex items-center gap-1 hover:text-gray-900 cursor-pointer"
                 >
                   Base imposable
                   {showSteps ? (
@@ -69,95 +137,36 @@ export const CehrComparisonTable = ({
                     Détail du calcul de la <strong>base lissée</strong> (colonne
                     « Avec quotient ») :
                   </div>
-                  <ol
-                    className={classNames(
-                      "list-decimal pl-6 space-y-1",
-                      "text-xs text-gray-700",
-                    )}
-                  >
-                    <li>
-                      Moyenne des deux années précédentes :{" "}
-                      <span className="font-mono">
-                        ({fmtEur(rfrNm2)} + {fmtEur(rfrNm1)}) / 2 ={" "}
-                        <strong>{fmtEur(result.averagePrevious)}</strong>
-                      </span>
-                    </li>
-                    <li>
-                      Fraction excédentaire :{" "}
-                      <span className="font-mono">
-                        {fmtEur(rfrN)} − {fmtEur(result.averagePrevious)} ={" "}
-                        <strong>{fmtEur(rfrN - result.averagePrevious)}</strong>
-                      </span>
-                    </li>
-                    <li>
-                      Fraction divisée par deux :{" "}
-                      <span className="font-mono">
-                        {fmtEur(rfrN - result.averagePrevious)} / 2 ={" "}
-                        <strong>
-                          {fmtEur((rfrN - result.averagePrevious) / 2)}
-                        </strong>
-                      </span>
-                    </li>
-                    <li>
-                      Base lissée :{" "}
-                      <span className="font-mono">
-                        {fmtEur(result.averagePrevious)} +{" "}
-                        {fmtEur((rfrN - result.averagePrevious) / 2)} ={" "}
-                        <strong className="text-green-700">
-                          {fmtEur(midpoint)}
-                        </strong>
-                      </span>
-                    </li>
+                  <ol className="list-decimal pl-6 space-y-1 text-xs text-gray-700">
+                    {steps.map((step, index) => (
+                      <li key={index}>{step}</li>
+                    ))}
                   </ol>
                 </td>
               </tr>
             )}
-            <tr>
-              <td className="p-3 text-gray-600">Base 3 %</td>
-              <td className="p-3 text-right">
-                {fmtEur(result.cehrWithoutQuotient.base3)}
-              </td>
-              <td className="p-3 text-right bg-green-50">
-                {fmtEur(midpointBreakdown.base3)}
-              </td>
-            </tr>
-            <tr>
-              <td className="p-3 text-gray-600">Base 4 %</td>
-              <td className="p-3 text-right">
-                {fmtEur(result.cehrWithoutQuotient.base4)}
-              </td>
-              <td className="p-3 text-right bg-green-50">
-                {fmtEur(midpointBreakdown.base4)}
-              </td>
-            </tr>
-            <tr>
-              <td className="p-3 text-gray-600">
-                CEHR à 3 %
-                <span className="text-xs text-gray-400 ml-1">
-                  (× 2 quotient)
-                </span>
-              </td>
-              <td className="p-3 text-right">
-                {fmtEur(result.cehrWithoutQuotient.amount3)}
-              </td>
-              <td className="p-3 text-right bg-green-50">
-                {fmtEur(midpointBreakdown.amount3 * 2)}
-              </td>
-            </tr>
-            <tr>
-              <td className="p-3 text-gray-600">
-                CEHR à 4 %
-                <span className="text-xs text-gray-400 ml-1">
-                  (× 2 quotient)
-                </span>
-              </td>
-              <td className="p-3 text-right">
-                {fmtEur(result.cehrWithoutQuotient.amount4)}
-              </td>
-              <td className="p-3 text-right bg-green-50">
-                {fmtEur(midpointBreakdown.amount4 * 2)}
-              </td>
-            </tr>
+            {rows.map(
+              (
+                {
+                  label,
+                  withoutQuotient,
+                  withQuotient,
+                  showQuotientMultiplier,
+                },
+                index,
+              ) => (
+                <tr key={index}>
+                  <td className="p-3 text-gray-600">{label}</td>
+                  <td className="p-3 text-right">{fmtEur(withoutQuotient)}</td>
+                  <td className="p-3 text-right bg-green-50">
+                    <span className="inline-flex items-baseline justify-end">
+                      {fmtEur(withQuotient)}
+                      {showQuotientMultiplier && <QuotientMultiplierBadge />}
+                    </span>
+                  </td>
+                </tr>
+              ),
+            )}
             <tr className="bg-gray-50">
               <td className="p-3 font-semibold">CEHR totale</td>
               <td className="p-3 text-right font-semibold">
@@ -170,13 +179,7 @@ export const CehrComparisonTable = ({
           </tbody>
         </table>
       </div>
-      <div
-        className={classNames(
-          "mt-4 p-4 rounded-md",
-          "bg-green-100 border border-green-300",
-          "flex items-baseline justify-between flex-wrap gap-2",
-        )}
-      >
+      <div className="mt-4 p-4 rounded-md bg-green-100 border border-green-300 flex items-baseline justify-between flex-wrap gap-2">
         <span className="text-sm text-green-900">
           Gain total grâce au lissage
           <span className="text-xs text-green-700 ml-2">

--- a/app/cehr/_CehrComparisonTable.tsx
+++ b/app/cehr/_CehrComparisonTable.tsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+import classNames from "classnames";
+import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
+import { Section } from "@/components/ui/Section";
+import {
+  fmtEur,
+  type CehrBreakdown,
+  type QuotientResult,
+} from "@/lib/taxes/cehr";
+
+interface Props {
+  result: QuotientResult;
+  rfrN: number;
+  rfrNm1: number;
+  rfrNm2: number;
+  midpoint: number;
+  midpointBreakdown: CehrBreakdown;
+}
+
+export const CehrComparisonTable = ({
+  result,
+  rfrN,
+  rfrNm1,
+  rfrNm2,
+  midpoint,
+  midpointBreakdown,
+}: Props) => {
+  const [showSteps, setShowSteps] = useState(false);
+
+  return (
+    <Section title="Comparaison du calcul CEHR">
+      <div className="border rounded-md overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-100 text-left">
+            <tr>
+              <th className="p-3 font-semibold">Élément</th>
+              <th className="p-3 font-semibold text-right">Sans quotient</th>
+              <th className="p-3 font-semibold text-right bg-green-50">
+                Avec quotient
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            <tr>
+              <td className="p-3 text-gray-600">
+                <button
+                  type="button"
+                  onClick={() => setShowSteps((s) => !s)}
+                  className={classNames(
+                    "flex items-center gap-1",
+                    "hover:text-gray-900 cursor-pointer",
+                  )}
+                >
+                  Base imposable
+                  {showSteps ? (
+                    <ChevronUpIcon className="h-3 w-3" />
+                  ) : (
+                    <ChevronDownIcon className="h-3 w-3" />
+                  )}
+                </button>
+              </td>
+              <td className="p-3 text-right">{fmtEur(rfrN)}</td>
+              <td className="p-3 text-right bg-green-50">{fmtEur(midpoint)}</td>
+            </tr>
+            {showSteps && (
+              <tr className="bg-gray-50">
+                <td colSpan={3} className="p-4">
+                  <div className="text-xs text-gray-600 mb-2">
+                    Détail du calcul de la <strong>base lissée</strong> (colonne
+                    « Avec quotient ») :
+                  </div>
+                  <ol
+                    className={classNames(
+                      "list-decimal pl-6 space-y-1",
+                      "text-xs text-gray-700",
+                    )}
+                  >
+                    <li>
+                      Moyenne des deux années précédentes :{" "}
+                      <span className="font-mono">
+                        ({fmtEur(rfrNm2)} + {fmtEur(rfrNm1)}) / 2 ={" "}
+                        <strong>{fmtEur(result.averagePrevious)}</strong>
+                      </span>
+                    </li>
+                    <li>
+                      Fraction excédentaire :{" "}
+                      <span className="font-mono">
+                        {fmtEur(rfrN)} − {fmtEur(result.averagePrevious)} ={" "}
+                        <strong>{fmtEur(rfrN - result.averagePrevious)}</strong>
+                      </span>
+                    </li>
+                    <li>
+                      Fraction divisée par deux :{" "}
+                      <span className="font-mono">
+                        {fmtEur(rfrN - result.averagePrevious)} / 2 ={" "}
+                        <strong>
+                          {fmtEur((rfrN - result.averagePrevious) / 2)}
+                        </strong>
+                      </span>
+                    </li>
+                    <li>
+                      Base lissée :{" "}
+                      <span className="font-mono">
+                        {fmtEur(result.averagePrevious)} +{" "}
+                        {fmtEur((rfrN - result.averagePrevious) / 2)} ={" "}
+                        <strong className="text-green-700">
+                          {fmtEur(midpoint)}
+                        </strong>
+                      </span>
+                    </li>
+                  </ol>
+                </td>
+              </tr>
+            )}
+            <tr>
+              <td className="p-3 text-gray-600">Base 3 %</td>
+              <td className="p-3 text-right">
+                {fmtEur(result.cehrWithoutQuotient.base3)}
+              </td>
+              <td className="p-3 text-right bg-green-50">
+                {fmtEur(midpointBreakdown.base3)}
+              </td>
+            </tr>
+            <tr>
+              <td className="p-3 text-gray-600">Base 4 %</td>
+              <td className="p-3 text-right">
+                {fmtEur(result.cehrWithoutQuotient.base4)}
+              </td>
+              <td className="p-3 text-right bg-green-50">
+                {fmtEur(midpointBreakdown.base4)}
+              </td>
+            </tr>
+            <tr>
+              <td className="p-3 text-gray-600">
+                CEHR à 3 %
+                <span className="text-xs text-gray-400 ml-1">
+                  (× 2 quotient)
+                </span>
+              </td>
+              <td className="p-3 text-right">
+                {fmtEur(result.cehrWithoutQuotient.amount3)}
+              </td>
+              <td className="p-3 text-right bg-green-50">
+                {fmtEur(midpointBreakdown.amount3 * 2)}
+              </td>
+            </tr>
+            <tr>
+              <td className="p-3 text-gray-600">
+                CEHR à 4 %
+                <span className="text-xs text-gray-400 ml-1">
+                  (× 2 quotient)
+                </span>
+              </td>
+              <td className="p-3 text-right">
+                {fmtEur(result.cehrWithoutQuotient.amount4)}
+              </td>
+              <td className="p-3 text-right bg-green-50">
+                {fmtEur(midpointBreakdown.amount4 * 2)}
+              </td>
+            </tr>
+            <tr className="bg-gray-50">
+              <td className="p-3 font-semibold">CEHR totale</td>
+              <td className="p-3 text-right font-semibold">
+                {fmtEur(result.cehrWithoutQuotient.total)}
+              </td>
+              <td className="p-3 text-right font-semibold bg-green-100">
+                {fmtEur(result.cehrWithQuotient)}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div
+        className={classNames(
+          "mt-4 p-4 rounded-md",
+          "bg-green-100 border border-green-300",
+          "flex items-baseline justify-between flex-wrap gap-2",
+        )}
+      >
+        <span className="text-sm text-green-900">
+          Gain total grâce au lissage
+          <span className="text-xs text-green-700 ml-2">
+            (CEHR sans quotient − CEHR avec quotient)
+          </span>
+        </span>
+        <span className="text-xl font-bold text-green-700">
+          {fmtEur(result.savings)}
+        </span>
+      </div>
+    </Section>
+  );
+};

--- a/app/cehr/_EligibilityInputs.tsx
+++ b/app/cehr/_EligibilityInputs.tsx
@@ -1,10 +1,7 @@
 import classNames from "classnames";
+import { ButtonGroup } from "@/components/ui/ButtonGroup";
 import { Section } from "@/components/ui/Section";
-import {
-  cehrEntryThreshold,
-  fmtEur,
-  type FoyerSituation,
-} from "@/lib/taxes/cehr";
+import { fmtEur, type FoyerSituation } from "@/lib/taxes/cehr";
 import { RfrField } from "./_RfrField";
 import type { CehrCalculatorView } from "./_useCehrCalculator";
 
@@ -46,27 +43,12 @@ export const EligibilityInputs = ({
     <div className="flex flex-col gap-4">
       <div>
         <div className="text-sm font-medium mb-2">Situation familiale</div>
-        <div className="inline-flex rounded-md shadow-sm border border-gray-300 overflow-hidden">
-          {SITUATION_OPTIONS.map((opt, idx) => {
-            const active = situation === opt.value;
-            return (
-              <button
-                key={opt.value}
-                type="button"
-                onClick={() => onSituationChange(opt.value)}
-                className={classNames(
-                  "px-4 py-1.5 text-sm transition-colors",
-                  idx > 0 && "border-l border-gray-300",
-                  active
-                    ? "bg-gray-100 text-gray-900 font-bold"
-                    : "bg-white text-gray-600 hover:bg-gray-50",
-                )}
-              >
-                {opt.label}
-              </button>
-            );
-          })}
-        </div>
+        <ButtonGroup
+          value={situation}
+          variant="segmented"
+          options={SITUATION_OPTIONS}
+          onClick={onSituationChange}
+        />
       </div>
 
       <RfrField
@@ -116,9 +98,9 @@ export const EligibilityInputs = ({
           <>
             Le RFR de l&apos;année précédant l&apos;année concernée doit être{" "}
             <strong>inférieur ou égal</strong> au seuil d&apos;entrée de la CEHR
-            (<strong>{fmtEur(cehrEntryThreshold(situation))}</strong> pour la
-            situation choisie). Si vous étiez déjà soumis à la CEHR cette
-            année-là, le lissage n&apos;est pas applicable.
+            (<strong>{fmtEur(view.entryThreshold)}</strong> pour la situation
+            choisie). Si vous étiez déjà soumis à la CEHR cette année-là, le
+            lissage n&apos;est pas applicable.
           </>
         }
         value={rfrNm1}
@@ -134,10 +116,10 @@ export const EligibilityInputs = ({
           <>
             Même condition deux ans en arrière : le RFR doit être{" "}
             <strong>inférieur ou égal</strong> à{" "}
-            <strong>{fmtEur(cehrEntryThreshold(situation))}</strong>. Les deux
-            années antérieures doivent être hors-CEHR pour que le revenu de
+            <strong>{fmtEur(view.entryThreshold)}</strong>. Les deux années
+            antérieures doivent être hors-CEHR pour que le revenu de
             l&apos;année N soit considéré comme exceptionnel par l&apos;article
-            223 sexies V du CGI.
+            223 sexies II du CGI.
           </>
         }
         value={rfrNm2}

--- a/app/cehr/_EligibilityInputs.tsx
+++ b/app/cehr/_EligibilityInputs.tsx
@@ -1,0 +1,151 @@
+import classNames from "classnames";
+import { Section } from "@/components/ui/Section";
+import {
+  cehrEntryThreshold,
+  fmtEur,
+  type FoyerSituation,
+} from "@/lib/taxes/cehr";
+import { RfrField } from "./_RfrField";
+import type { CehrCalculatorView } from "./_useCehrCalculator";
+
+const SITUATION_OPTIONS: Array<{ label: string; value: FoyerSituation }> = [
+  { label: "Couple (marié·e / pacsé·e)", value: "couple" },
+  { label: "Célibataire / divorcé·e / veuf·ve", value: "single" },
+];
+
+interface Props {
+  yearN: number;
+  yearOptions: Array<{ label: string; value: number }>;
+  situation: FoyerSituation;
+  rfrN: number | null;
+  rfrNm1: number | null;
+  rfrNm2: number | null;
+  view: CehrCalculatorView;
+  onYearChange: (y: number) => void;
+  onSituationChange: (s: FoyerSituation) => void;
+  onRfrNChange: (v: number | null) => void;
+  onRfrNm1Change: (v: number | null) => void;
+  onRfrNm2Change: (v: number | null) => void;
+}
+
+export const EligibilityInputs = ({
+  yearN,
+  yearOptions,
+  situation,
+  rfrN,
+  rfrNm1,
+  rfrNm2,
+  view,
+  onYearChange,
+  onSituationChange,
+  onRfrNChange,
+  onRfrNm1Change,
+  onRfrNm2Change,
+}: Props) => (
+  <Section title="Vos informations">
+    <div className="flex flex-col gap-4">
+      <div>
+        <div className="text-sm font-medium mb-2">Situation familiale</div>
+        <div className="inline-flex rounded-md shadow-sm border border-gray-300 overflow-hidden">
+          {SITUATION_OPTIONS.map((opt, idx) => {
+            const active = situation === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => onSituationChange(opt.value)}
+                className={classNames(
+                  "px-4 py-1.5 text-sm transition-colors",
+                  idx > 0 && "border-l border-gray-300",
+                  active
+                    ? "bg-gray-100 text-gray-900 font-bold"
+                    : "bg-white text-gray-600 hover:bg-gray-50",
+                )}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <RfrField
+        label={
+          <span className="flex items-center gap-2 flex-wrap">
+            <span>RFR de l&apos;année concernée</span>
+            <span className="flex items-center gap-1">
+              <span className="text-xs font-normal text-gray-500">année :</span>
+              <select
+                value={String(yearN)}
+                onChange={(e) => onYearChange(Number(e.target.value))}
+                className={classNames(
+                  "bg-transparent border rounded px-2 py-0.5",
+                  "text-sm font-semibold border-gray-300",
+                  "hover:border-gray-400 focus:outline-none",
+                  "cursor-pointer",
+                )}
+              >
+                {yearOptions.map((opt) => (
+                  <option key={opt.value} value={String(opt.value)}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </span>
+        }
+        explanation={
+          <>
+            Le revenu fiscal de référence de l&apos;année concernée (celle de
+            l&apos;avis d&apos;imposition que vous contestez) doit être{" "}
+            <strong>au moins 1,5 fois</strong> la moyenne des RFR des deux
+            années précédentes. C&apos;est l&apos;écart de revenu qui ouvre
+            droit au lissage.
+          </>
+        }
+        value={rfrN}
+        onChange={onRfrNChange}
+        placeholder="ex. 800 000"
+        status={view.n.status}
+        checkDetail={view.n.detail}
+      />
+
+      <RfrField
+        label={`RFR ${yearN - 1} (N-1)`}
+        explanation={
+          <>
+            Le RFR de l&apos;année précédant l&apos;année concernée doit être{" "}
+            <strong>inférieur ou égal</strong> au seuil d&apos;entrée de la CEHR
+            (<strong>{fmtEur(cehrEntryThreshold(situation))}</strong> pour la
+            situation choisie). Si vous étiez déjà soumis à la CEHR cette
+            année-là, le lissage n&apos;est pas applicable.
+          </>
+        }
+        value={rfrNm1}
+        onChange={onRfrNm1Change}
+        placeholder="ex. 100 000"
+        status={view.nm1.status}
+        checkDetail={view.nm1.detail}
+      />
+
+      <RfrField
+        label={`RFR ${yearN - 2} (N-2)`}
+        explanation={
+          <>
+            Même condition deux ans en arrière : le RFR doit être{" "}
+            <strong>inférieur ou égal</strong> à{" "}
+            <strong>{fmtEur(cehrEntryThreshold(situation))}</strong>. Les deux
+            années antérieures doivent être hors-CEHR pour que le revenu de
+            l&apos;année N soit considéré comme exceptionnel par l&apos;article
+            223 sexies V du CGI.
+          </>
+        }
+        value={rfrNm2}
+        onChange={onRfrNm2Change}
+        placeholder="ex. 200 000"
+        status={view.nm2.status}
+        checkDetail={view.nm2.detail}
+      />
+    </div>
+  </Section>
+);

--- a/app/cehr/_EmailPreview.tsx
+++ b/app/cehr/_EmailPreview.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import classNames from "classnames";
+import toast from "react-hot-toast";
+import { ClipboardIcon, CheckIcon } from "@heroicons/react/24/solid";
+import { Section } from "@/components/ui/Section";
+
+interface Props {
+  email: string;
+}
+
+export const EmailPreview = ({ email }: Props) => {
+  const [copied, setCopied] = useState(false);
+  const onCopy = () => {
+    if (!email) return;
+    navigator.clipboard.writeText(email);
+    setCopied(true);
+    toast.success("Email copié dans le presse-papier");
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Section
+      title="Email à envoyer au SIP"
+      actions={
+        <button
+          type="button"
+          onClick={onCopy}
+          className={classNames(
+            "flex items-center gap-2 px-3 py-1.5 rounded shadow text-sm font-semibold hover:opacity-75",
+            copied ? "bg-green-200" : "bg-blue-100",
+          )}
+        >
+          {copied ? (
+            <CheckIcon className="h-4 w-4" />
+          ) : (
+            <ClipboardIcon className="h-4 w-4" />
+          )}
+          {copied ? "Copié" : "Copier l'email"}
+        </button>
+      }
+    >
+      <textarea
+        readOnly
+        value={email}
+        className={classNames(
+          "w-full h-[28rem] font-mono text-xs",
+          "border rounded-md p-3 bg-white",
+        )}
+      />
+      <p className="text-xs text-gray-500 mt-2">
+        À déposer via la messagerie sécurisée impots.gouv.fr, rubrique «{" "}
+        J&apos;ai une question sur le calcul de mon impôt », après réception de
+        l&apos;avis d&apos;imposition. Joindre les justificatifs listés en bas
+        du courrier.
+      </p>
+    </Section>
+  );
+};

--- a/app/cehr/_EmailPreview.tsx
+++ b/app/cehr/_EmailPreview.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import classNames from "classnames";
 import toast from "react-hot-toast";
 import { ClipboardIcon, CheckIcon } from "@heroicons/react/24/solid";
 import { Section } from "@/components/ui/Section";
+import { Button } from "@/components/ui/Button";
 
 interface Props {
   email: string;
@@ -12,42 +12,34 @@ interface Props {
 
 export const EmailPreview = ({ email }: Props) => {
   const [copied, setCopied] = useState(false);
-  const onCopy = () => {
+  const onCopy = async () => {
     if (!email) return;
-    navigator.clipboard.writeText(email);
-    setCopied(true);
-    toast.success("Email copié dans le presse-papier");
-    setTimeout(() => setCopied(false), 1500);
+    try {
+      await navigator.clipboard.writeText(email);
+      setCopied(true);
+      toast.success("Email copié dans le presse-papier");
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error("Impossible de copier l'email");
+    }
   };
 
   return (
     <Section
       title="Email à envoyer au SIP"
       actions={
-        <button
-          type="button"
+        <Button
           onClick={onCopy}
-          className={classNames(
-            "flex items-center gap-2 px-3 py-1.5 rounded shadow text-sm font-semibold hover:opacity-75",
-            copied ? "bg-green-200" : "bg-blue-100",
-          )}
-        >
-          {copied ? (
-            <CheckIcon className="h-4 w-4" />
-          ) : (
-            <ClipboardIcon className="h-4 w-4" />
-          )}
-          {copied ? "Copié" : "Copier l'email"}
-        </button>
+          color={copied ? "softGreen" : "blue"}
+          icon={copied ? CheckIcon : ClipboardIcon}
+          label={copied ? "Copié" : "Copier l'email"}
+        />
       }
     >
       <textarea
         readOnly
         value={email}
-        className={classNames(
-          "w-full h-[28rem] font-mono text-xs",
-          "border rounded-md p-3 bg-white",
-        )}
+        className="w-full h-[28rem] font-mono text-xs border rounded-md p-3 bg-white"
       />
       <p className="text-xs text-gray-500 mt-2">
         À déposer via la messagerie sécurisée impots.gouv.fr, rubrique «{" "}

--- a/app/cehr/_Header.tsx
+++ b/app/cehr/_Header.tsx
@@ -1,0 +1,26 @@
+export const Header = () => (
+  <header>
+    <h1 className="text-3xl font-semibold">
+      Puis-je réduire une partie de mes impôts ?
+    </h1>
+    <p className="text-sm text-gray-600 mt-3 max-w-3xl">
+      Une année avec beaucoup de cessions d&apos;actions (RSU, ESPP,
+      stock-options) peut déclencher la{" "}
+      <strong>Contribution Exceptionnelle sur les Hauts Revenus (CEHR)</strong>,
+      une surtaxe de 3 à 4 % qui s&apos;applique au-delà d&apos;un certain seuil
+      de revenu fiscal de référence. Le code des impôts prévoit un mécanisme de
+      lissage qui ramène la base de calcul à un niveau plus proche de la moyenne
+      de vos années précédentes — ce qui peut sérieusement réduire la facture.
+    </p>
+    <p className="text-sm text-gray-600 mt-3 max-w-3xl">
+      Ce lissage est censé être appliqué automatiquement, mais il arrive que le
+      SIP l&apos;oublie. Et si votre situation familiale a changé sur la période
+      (mariage, PACS, divorce, décès), c&apos;est à vous de faire la démarche
+      pour fournir les bons revenus de référence.
+    </p>
+    <p className="text-sm text-gray-600 mt-3 max-w-3xl">
+      Cet outil estime ce que votre CEHR <em>devrait</em> être avec lissage, et
+      génère le courrier de réclamation à envoyer aux impôts si nécessaire.
+    </p>
+  </header>
+);

--- a/app/cehr/_References.tsx
+++ b/app/cehr/_References.tsx
@@ -1,46 +1,38 @@
 import { Section } from "@/components/ui/Section";
+import { Link } from "@/components/ui/Link";
+
+const REFERENCES = [
+  {
+    href: "https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036427364",
+    label: "Article 223 sexies du Code Général des Impôts (Légifrance)",
+    description:
+      "base légale de la CEHR (I) et du mécanisme de lissage (II.1). Le II.2 précise le cas spécifique d'une modification de la situation familiale, pour lequel le dépôt d'une réclamation est explicitement requis.",
+  },
+  {
+    href: "https://bofip.impots.gouv.fr/bofip/7804-PGP.html/identifiant=BOI-IR-CHR-20170711",
+    label:
+      "BOI-IR-CHR — Contribution exceptionnelle sur les hauts revenus (BOFiP)",
+    description:
+      "doctrine administrative officielle de la DGFiP : champ d'application, calcul, mécanisme de lissage et procédure de réclamation.",
+  },
+  {
+    href: "https://prosper-conseil.fr/optimisation-fiscale/cehr-calcul-bareme-et-lissage/",
+    label: "Prosper Conseil — CEHR : calcul, barème et lissage",
+    description: "synthèse pédagogique avec exemples chiffrés.",
+  },
+];
 
 export const References = () => (
   <Section title="Références">
     <ul className="text-sm space-y-2 text-gray-700">
-      <li>
-        <a
-          href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036427364"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
-        >
-          Article 223 sexies du Code Général des Impôts (Légifrance)
-        </a>{" "}
-        — base légale de la CEHR (I) et du mécanisme de lissage (II.1). Le II.2
-        précise le cas spécifique d&apos;une modification de la situation
-        familiale, pour lequel le dépôt d&apos;une réclamation est explicitement
-        requis.
-      </li>
-      <li>
-        <a
-          href="https://bofip.impots.gouv.fr/bofip/7804-PGP.html/identifiant=BOI-IR-CHR-20170711"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
-        >
-          BOI-IR-CHR — Contribution exceptionnelle sur les hauts revenus (BOFiP)
-        </a>{" "}
-        — doctrine administrative officielle de la DGFiP : champ
-        d&apos;application, calcul, mécanisme de lissage et procédure de
-        réclamation.
-      </li>
-      <li>
-        <a
-          href="https://prosper-conseil.fr/optimisation-fiscale/cehr-calcul-bareme-et-lissage/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
-        >
-          Prosper Conseil — CEHR : calcul, barème et lissage
-        </a>{" "}
-        — synthèse pédagogique avec exemples chiffrés.
-      </li>
+      {REFERENCES.map(({ href, label, description }) => (
+        <li key={href}>
+          <Link href={href} isExternal variant="blue">
+            {label}
+          </Link>{" "}
+          — {description}
+        </li>
+      ))}
     </ul>
   </Section>
 );

--- a/app/cehr/_References.tsx
+++ b/app/cehr/_References.tsx
@@ -1,0 +1,46 @@
+import { Section } from "@/components/ui/Section";
+
+export const References = () => (
+  <Section title="Références">
+    <ul className="text-sm space-y-2 text-gray-700">
+      <li>
+        <a
+          href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036427364"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Article 223 sexies du Code Général des Impôts (Légifrance)
+        </a>{" "}
+        — base légale de la CEHR (I) et du mécanisme de lissage (II.1). Le II.2
+        précise le cas spécifique d&apos;une modification de la situation
+        familiale, pour lequel le dépôt d&apos;une réclamation est explicitement
+        requis.
+      </li>
+      <li>
+        <a
+          href="https://bofip.impots.gouv.fr/bofip/7804-PGP.html/identifiant=BOI-IR-CHR-20170711"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          BOI-IR-CHR — Contribution exceptionnelle sur les hauts revenus (BOFiP)
+        </a>{" "}
+        — doctrine administrative officielle de la DGFiP : champ
+        d&apos;application, calcul, mécanisme de lissage et procédure de
+        réclamation.
+      </li>
+      <li>
+        <a
+          href="https://prosper-conseil.fr/optimisation-fiscale/cehr-calcul-bareme-et-lissage/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Prosper Conseil — CEHR : calcul, barème et lissage
+        </a>{" "}
+        — synthèse pédagogique avec exemples chiffrés.
+      </li>
+    </ul>
+  </Section>
+);

--- a/app/cehr/_RfrField.tsx
+++ b/app/cehr/_RfrField.tsx
@@ -1,0 +1,51 @@
+import classNames from "classnames";
+import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/solid";
+import { NumberInput } from "@/components/ui/Field";
+
+export type CheckStatus = "neutral" | "passed" | "failed";
+
+interface RfrFieldProps {
+  label: React.ReactNode;
+  explanation: React.ReactNode;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  placeholder?: string;
+  status: CheckStatus;
+  checkDetail?: string;
+}
+
+export const RfrField = ({
+  label,
+  explanation,
+  value,
+  onChange,
+  placeholder,
+  status,
+  checkDetail,
+}: RfrFieldProps) => (
+  <div
+    className={classNames(
+      "border rounded-md p-4 max-w-3xl",
+      status === "passed" && "border-green-300 bg-green-50/40",
+      status === "failed" && "border-red-300 bg-red-50/40",
+      status === "neutral" && "border-gray-200 bg-white",
+    )}
+  >
+    <div className="flex items-center gap-2 text-sm font-semibold mb-1">
+      {label}
+      {status === "passed" && (
+        <CheckCircleIcon className="h-4 w-4 text-green-600" />
+      )}
+      {status === "failed" && <XCircleIcon className="h-4 w-4 text-red-600" />}
+    </div>
+    <div className="text-xs text-gray-600 mb-3">{explanation}</div>
+    <NumberInput
+      value={value}
+      onChange={(v) => onChange(Number.isNaN(v) ? null : v)}
+      min={0}
+      maxDecimals={0}
+      placeholder={placeholder}
+      validationError={status === "failed" ? checkDetail : null}
+    />
+  </div>
+);

--- a/app/cehr/_useCehrCalculator.ts
+++ b/app/cehr/_useCehrCalculator.ts
@@ -1,0 +1,150 @@
+import { useMemo } from "react";
+import {
+  cehrEntryThreshold,
+  computeCehr,
+  computeQuotient,
+  evaluateFieldStatus,
+  fmtEur,
+  type CehrBreakdown,
+  type FoyerSituation,
+  type QuotientResult,
+} from "@/lib/taxes/cehr";
+import { buildCehrEmail, type AssetType } from "@/lib/taxes/cehr-template";
+import type { CheckStatus } from "./_RfrField";
+
+interface Inputs {
+  yearN: number;
+  situation: FoyerSituation;
+  rfrN: number | null;
+  rfrNm1: number | null;
+  rfrNm2: number | null;
+  assetTypes: AssetType[];
+}
+
+interface FieldUi {
+  status: CheckStatus;
+  detail?: string;
+}
+
+export interface CehrCalculatorView {
+  allFilled: boolean;
+  entryThreshold: number;
+  nm1: FieldUi;
+  nm2: FieldUi;
+  n: FieldUi;
+  result: QuotientResult | null;
+  midpoint: number;
+  midpointBreakdown: CehrBreakdown;
+  email: string;
+}
+
+const EMPTY_BREAKDOWN: CehrBreakdown = {
+  rfr: 0,
+  base3: 0,
+  base4: 0,
+  amount3: 0,
+  amount4: 0,
+  total: 0,
+};
+
+export const useCehrCalculator = ({
+  yearN,
+  situation,
+  rfrN,
+  rfrNm1,
+  rfrNm2,
+  assetTypes,
+}: Inputs): CehrCalculatorView => {
+  const allFilled = rfrN !== null && rfrNm1 !== null && rfrNm2 !== null;
+  const entryThreshold = cehrEntryThreshold(situation);
+
+  const statusNm1 = evaluateFieldStatus({
+    rfrN,
+    rfrNm1,
+    rfrNm2,
+    situation,
+    field: "Nm1",
+  });
+  const detailNm1 =
+    statusNm1 === "failed" && rfrNm1 !== null
+      ? `RFR N-1 = ${fmtEur(rfrNm1)} ≥ ${fmtEur(entryThreshold)}`
+      : undefined;
+
+  const statusNm2 = evaluateFieldStatus({
+    rfrN,
+    rfrNm1,
+    rfrNm2,
+    situation,
+    field: "Nm2",
+  });
+  const detailNm2 =
+    statusNm2 === "failed" && rfrNm2 !== null
+      ? `RFR N-2 = ${fmtEur(rfrNm2)} ≥ ${fmtEur(entryThreshold)}`
+      : undefined;
+
+  const statusN = evaluateFieldStatus({
+    rfrN,
+    rfrNm1,
+    rfrNm2,
+    situation,
+    field: "N",
+  });
+  const detailN = (() => {
+    if (statusN !== "failed" || rfrN === null) return undefined;
+    if (rfrN <= entryThreshold) {
+      return `RFR N = ${fmtEur(rfrN)} ≤ ${fmtEur(
+        entryThreshold,
+      )} (seuil CEHR) — aucune CEHR n'est due, le lissage est sans objet.`;
+    }
+    if (rfrNm1 !== null && rfrNm2 !== null) {
+      return `RFR N = ${fmtEur(rfrN)} < 1,5 × moyenne (${fmtEur(
+        1.5 * ((rfrNm1 + rfrNm2) / 2),
+      )})`;
+    }
+    return undefined;
+  })();
+
+  const result = useMemo(() => {
+    if (!allFilled) return null;
+    return computeQuotient({
+      rfrN: rfrN!,
+      rfrNm1: rfrNm1!,
+      rfrNm2: rfrNm2!,
+      situation,
+    });
+  }, [allFilled, rfrN, rfrNm1, rfrNm2, situation]);
+
+  const midpoint = result
+    ? result.averagePrevious + (rfrN! - result.averagePrevious) / 2
+    : 0;
+  const midpointBreakdown = result
+    ? computeCehr(midpoint, situation)
+    : EMPTY_BREAKDOWN;
+
+  const email = useMemo(() => {
+    if (!result || !allFilled || !result.eligible || assetTypes.length === 0) {
+      return "";
+    }
+    return buildCehrEmail({
+      yearN,
+      rfrN: rfrN!,
+      rfrNm1: rfrNm1!,
+      rfrNm2: rfrNm2!,
+      quotient: result,
+      assetTypes,
+      situation,
+    });
+  }, [result, allFilled, yearN, rfrN, rfrNm1, rfrNm2, assetTypes, situation]);
+
+  return {
+    allFilled,
+    entryThreshold,
+    nm1: { status: statusNm1, detail: detailNm1 },
+    nm2: { status: statusNm2, detail: detailNm2 },
+    n: { status: statusN, detail: detailN },
+    result,
+    midpoint,
+    midpointBreakdown,
+    email,
+  };
+};

--- a/app/cehr/_useCehrCalculator.ts
+++ b/app/cehr/_useCehrCalculator.ts
@@ -44,8 +44,19 @@ const EMPTY_BREAKDOWN: CehrBreakdown = {
   base4: 0,
   amount3: 0,
   amount4: 0,
+  rawTotal: 0,
   total: 0,
 };
+
+const failedPreviousDetail = (
+  label: "N-1" | "N-2",
+  value: number | null,
+  threshold: number,
+  status: CheckStatus,
+) =>
+  status === "failed" && value !== null
+    ? `RFR ${label} = ${fmtEur(value)} > ${fmtEur(threshold)}`
+    : undefined;
 
 export const useCehrCalculator = ({
   yearN,
@@ -57,38 +68,24 @@ export const useCehrCalculator = ({
 }: Inputs): CehrCalculatorView => {
   const allFilled = rfrN !== null && rfrNm1 !== null && rfrNm2 !== null;
   const entryThreshold = cehrEntryThreshold(situation);
+  const statusFor = (field: "N" | "Nm1" | "Nm2") =>
+    evaluateFieldStatus({ rfrN, rfrNm1, rfrNm2, situation, field });
 
-  const statusNm1 = evaluateFieldStatus({
-    rfrN,
+  const statusNm1 = statusFor("Nm1");
+  const statusNm2 = statusFor("Nm2");
+  const statusN = statusFor("N");
+  const detailNm1 = failedPreviousDetail(
+    "N-1",
     rfrNm1,
+    entryThreshold,
+    statusNm1,
+  );
+  const detailNm2 = failedPreviousDetail(
+    "N-2",
     rfrNm2,
-    situation,
-    field: "Nm1",
-  });
-  const detailNm1 =
-    statusNm1 === "failed" && rfrNm1 !== null
-      ? `RFR N-1 = ${fmtEur(rfrNm1)} ≥ ${fmtEur(entryThreshold)}`
-      : undefined;
-
-  const statusNm2 = evaluateFieldStatus({
-    rfrN,
-    rfrNm1,
-    rfrNm2,
-    situation,
-    field: "Nm2",
-  });
-  const detailNm2 =
-    statusNm2 === "failed" && rfrNm2 !== null
-      ? `RFR N-2 = ${fmtEur(rfrNm2)} ≥ ${fmtEur(entryThreshold)}`
-      : undefined;
-
-  const statusN = evaluateFieldStatus({
-    rfrN,
-    rfrNm1,
-    rfrNm2,
-    situation,
-    field: "N",
-  });
+    entryThreshold,
+    statusNm2,
+  );
   const detailN = (() => {
     if (statusN !== "failed" || rfrN === null) return undefined;
     if (rfrN <= entryThreshold) {

--- a/app/cehr/page.tsx
+++ b/app/cehr/page.tsx
@@ -296,8 +296,8 @@ export default function CehrPage() {
             explanation={
               <>
                 Le RFR de l&apos;année précédant l&apos;année concernée doit
-                être <strong>strictement inférieur</strong> au seuil
-                d&apos;entrée de la CEHR (
+                être <strong>inférieur ou égal</strong> au seuil d&apos;entrée
+                de la CEHR (
                 <strong>{fmtEur(cehrEntryThreshold(situation))}</strong> pour la
                 situation choisie). Si vous étiez déjà soumis à la CEHR cette
                 année-là, le lissage n&apos;est pas applicable.
@@ -315,7 +315,7 @@ export default function CehrPage() {
             explanation={
               <>
                 Même condition deux ans en arrière : le RFR doit être{" "}
-                <strong>strictement inférieur</strong> à{" "}
+                <strong>inférieur ou égal</strong> à{" "}
                 <strong>{fmtEur(cehrEntryThreshold(situation))}</strong>. Les
                 deux années antérieures doivent être hors-CEHR pour que le
                 revenu de l&apos;année N soit considéré comme exceptionnel par

--- a/app/cehr/page.tsx
+++ b/app/cehr/page.tsx
@@ -1,0 +1,643 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import classNames from "classnames";
+import toast from "react-hot-toast";
+import {
+  ClipboardIcon,
+  CheckIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/react/24/solid";
+import { NumberInput } from "@/components/ui/Field";
+import { Section } from "@/components/ui/Section";
+import {
+  cehrEntryThreshold,
+  computeCehr,
+  computeQuotient,
+  evaluateFieldStatus,
+  type FoyerSituation,
+} from "@/lib/taxes/cehr";
+import {
+  ASSET_DEFINITIONS,
+  buildCehrEmail,
+  type AssetType,
+} from "@/lib/taxes/cehr-template";
+
+const fmtEur = (n: number): string =>
+  `${Math.round(n).toLocaleString("fr-FR")} €`;
+
+const CURRENT_YEAR = new Date().getFullYear();
+const YEAR_OPTIONS = Array.from({ length: 10 }, (_, i) => CURRENT_YEAR - i).map(
+  (y) => ({ label: String(y), value: y }),
+);
+
+const SITUATION_OPTIONS: Array<{ label: string; value: FoyerSituation }> = [
+  { label: "Couple (marié·e / pacsé·e)", value: "couple" },
+  { label: "Célibataire / divorcé·e / veuf·ve", value: "single" },
+];
+
+type CheckStatus = "neutral" | "passed" | "failed";
+
+interface RfrFieldProps {
+  label: React.ReactNode;
+  explanation: React.ReactNode;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  placeholder?: string;
+  status: CheckStatus;
+  checkDetail?: string;
+}
+
+const RfrField = ({
+  label,
+  explanation,
+  value,
+  onChange,
+  placeholder,
+  status,
+  checkDetail,
+}: RfrFieldProps) => (
+  <div
+    className={classNames(
+      "border rounded-md p-4 max-w-3xl",
+      status === "passed" && "border-green-300 bg-green-50/40",
+      status === "failed" && "border-red-300 bg-red-50/40",
+      status === "neutral" && "border-gray-200 bg-white",
+    )}
+  >
+    <div className="flex items-center gap-2 text-sm font-semibold mb-1">
+      {label}
+      {status === "passed" && (
+        <CheckCircleIcon className="h-4 w-4 text-green-600" />
+      )}
+      {status === "failed" && <XCircleIcon className="h-4 w-4 text-red-600" />}
+    </div>
+    <div className="text-xs text-gray-600 mb-3">{explanation}</div>
+    <NumberInput
+      value={value}
+      onChange={(v) => onChange(Number.isNaN(v) ? null : v)}
+      min={0}
+      maxDecimals={0}
+      placeholder={placeholder}
+      validationError={status === "failed" ? checkDetail : null}
+    />
+  </div>
+);
+
+export default function CehrPage() {
+  const [yearN, setYearN] = useState<number>(CURRENT_YEAR - 1);
+  const [situation, setSituation] = useState<FoyerSituation>("single");
+  const [rfrN, setRfrN] = useState<number | null>(null);
+  const [rfrNm1, setRfrNm1] = useState<number | null>(null);
+  const [rfrNm2, setRfrNm2] = useState<number | null>(null);
+  const [assetTypes, setAssetTypes] = useState<AssetType[]>(["rsu"]);
+
+  const toggleAsset = (id: AssetType) => {
+    setAssetTypes((prev) =>
+      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id],
+    );
+  };
+
+  const allFilled = rfrN !== null && rfrNm1 !== null && rfrNm2 !== null;
+  const entryThreshold = cehrEntryThreshold(situation);
+
+  const statusNm1 = evaluateFieldStatus({
+    rfrN,
+    rfrNm1,
+    rfrNm2,
+    situation,
+    field: "Nm1",
+  });
+  const detailNm1 =
+    statusNm1 === "failed" && rfrNm1 !== null
+      ? `RFR N-1 = ${fmtEur(rfrNm1)} ≥ ${fmtEur(entryThreshold)}`
+      : undefined;
+
+  const statusNm2 = evaluateFieldStatus({
+    rfrN,
+    rfrNm1,
+    rfrNm2,
+    situation,
+    field: "Nm2",
+  });
+  const detailNm2 =
+    statusNm2 === "failed" && rfrNm2 !== null
+      ? `RFR N-2 = ${fmtEur(rfrNm2)} ≥ ${fmtEur(entryThreshold)}`
+      : undefined;
+
+  const statusN = evaluateFieldStatus({
+    rfrN,
+    rfrNm1,
+    rfrNm2,
+    situation,
+    field: "N",
+  });
+  const detailN = (() => {
+    if (statusN !== "failed" || rfrN === null) return undefined;
+    if (rfrN <= entryThreshold) {
+      return `RFR N = ${fmtEur(rfrN)} ≤ ${fmtEur(
+        entryThreshold,
+      )} (seuil CEHR) — aucune CEHR n'est due, le lissage est sans objet.`;
+    }
+    if (rfrNm1 !== null && rfrNm2 !== null) {
+      return `RFR N = ${fmtEur(rfrN)} < 1,5 × moyenne (${fmtEur(
+        1.5 * ((rfrNm1 + rfrNm2) / 2),
+      )})`;
+    }
+    return undefined;
+  })();
+
+  const result = useMemo(() => {
+    if (!allFilled) return null;
+    return computeQuotient({
+      rfrN: rfrN!,
+      rfrNm1: rfrNm1!,
+      rfrNm2: rfrNm2!,
+      situation,
+    });
+  }, [allFilled, rfrN, rfrNm1, rfrNm2, situation]);
+
+  const midpoint = result
+    ? result.averagePrevious + (rfrN! - result.averagePrevious) / 2
+    : 0;
+  const midpointBreakdown = result
+    ? computeCehr(midpoint, situation)
+    : { rfr: 0, base3: 0, base4: 0, amount3: 0, amount4: 0, total: 0 };
+
+  const email = useMemo(() => {
+    if (!result || !allFilled || !result.eligible || assetTypes.length === 0) {
+      return "";
+    }
+    return buildCehrEmail({
+      yearN,
+      rfrN: rfrN!,
+      rfrNm1: rfrNm1!,
+      rfrNm2: rfrNm2!,
+      quotient: result,
+      assetTypes,
+      situation,
+    });
+  }, [result, allFilled, yearN, rfrN, rfrNm1, rfrNm2, assetTypes, situation]);
+
+  const [showSteps, setShowSteps] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const onCopy = () => {
+    if (!email) return;
+    navigator.clipboard.writeText(email);
+    setCopied(true);
+    toast.success("Email copié dans le presse-papier");
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="flex flex-col gap-8 px-4">
+      <header>
+        <h1 className="text-3xl font-semibold">
+          Puis-je réduire une partie de mes impôts ?
+        </h1>
+        <p className="text-sm text-gray-600 mt-2 max-w-3xl">
+          Si vous avez eu une année de revenus exceptionnellement élevée (vente
+          d&apos;actions, RSU, stock-options, prime ou indemnité importante),
+          vous avez peut-être payé une surtaxe appelée
+          <strong>
+            {" "}
+            Contribution Exceptionnelle sur les Hauts Revenus (CEHR)
+          </strong>
+          . La loi prévoit un mécanisme de « lissage » qui permet de la
+          recalculer en tenant compte de vos revenus des deux années précédentes
+          — et donc, souvent, de la réduire fortement. Cet outil vérifie si vous
+          y avez droit, calcule l&apos;économie potentielle, et génère le
+          courrier de réclamation à envoyer aux impôts.
+        </p>
+      </header>
+
+      <Section title="Vos informations">
+        <div className="flex flex-col gap-4">
+          <div>
+            <div className="text-sm font-medium mb-2">Situation familiale</div>
+            <div className="text-xs text-gray-500 mb-2 max-w-3xl">
+              Cet outil suppose que la situation familiale est restée identique
+              sur les trois années (N-2, N-1, N). Si elle a changé (mariage,
+              PACS, divorce, décès), les seuils CEHR applicables aux RFR
+              antérieurs peuvent différer — vérifiez manuellement avant
+              d&apos;envoyer le courrier.
+            </div>
+            <div className="inline-flex rounded-md shadow-sm border border-gray-300 overflow-hidden">
+              {SITUATION_OPTIONS.map((opt, idx) => {
+                const active = situation === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setSituation(opt.value)}
+                    className={classNames(
+                      "px-4 py-1.5 text-sm transition-colors",
+                      idx > 0 && "border-l border-gray-300",
+                      active
+                        ? "bg-gray-100 text-gray-900 font-bold"
+                        : "bg-white text-gray-600 hover:bg-gray-50",
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <RfrField
+            label={
+              <span className="flex items-center gap-2 flex-wrap">
+                <span>RFR de l&apos;année concernée</span>
+                <span className="flex items-center gap-1">
+                  <span className="text-xs font-normal text-gray-500">
+                    année :
+                  </span>
+                  <select
+                    value={String(yearN)}
+                    onChange={(e) => setYearN(Number(e.target.value))}
+                    className={classNames(
+                      "bg-transparent border rounded px-2 py-0.5",
+                      "text-sm font-semibold border-gray-300",
+                      "hover:border-gray-400 focus:outline-none",
+                      "cursor-pointer",
+                    )}
+                  >
+                    {YEAR_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={String(opt.value)}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </span>
+              </span>
+            }
+            explanation={
+              <>
+                Le revenu fiscal de référence de l&apos;année concernée (celle
+                de l&apos;avis d&apos;imposition que vous contestez) doit être{" "}
+                <strong>au moins 1,5 fois</strong> la moyenne des RFR des deux
+                années précédentes. C&apos;est l&apos;écart de revenu qui ouvre
+                droit au lissage.
+              </>
+            }
+            value={rfrN}
+            onChange={setRfrN}
+            placeholder="ex. 800 000"
+            status={statusN}
+            checkDetail={detailN}
+          />
+
+          <RfrField
+            label={`RFR ${yearN - 1} (N-1)`}
+            explanation={
+              <>
+                Le RFR de l&apos;année précédant l&apos;année concernée doit
+                être <strong>strictement inférieur</strong> au seuil
+                d&apos;entrée de la CEHR (
+                <strong>{fmtEur(cehrEntryThreshold(situation))}</strong> pour la
+                situation choisie). Si vous étiez déjà soumis à la CEHR cette
+                année-là, le lissage n&apos;est pas applicable.
+              </>
+            }
+            value={rfrNm1}
+            onChange={setRfrNm1}
+            placeholder="ex. 100 000"
+            status={statusNm1}
+            checkDetail={detailNm1}
+          />
+
+          <RfrField
+            label={`RFR ${yearN - 2} (N-2)`}
+            explanation={
+              <>
+                Même condition deux ans en arrière : le RFR doit être{" "}
+                <strong>strictement inférieur</strong> à{" "}
+                <strong>{fmtEur(cehrEntryThreshold(situation))}</strong>. Les
+                deux années antérieures doivent être hors-CEHR pour que le
+                revenu de l&apos;année N soit considéré comme exceptionnel par
+                l&apos;article 223 sexies V du CGI.
+              </>
+            }
+            value={rfrNm2}
+            onChange={setRfrNm2}
+            placeholder="ex. 200 000"
+            status={statusNm2}
+            checkDetail={detailNm2}
+          />
+        </div>
+      </Section>
+
+      {result && !result.eligible && (
+        <div className="p-3 rounded-md bg-yellow-50 text-sm border border-yellow-200">
+          Le système du quotient n&apos;est pas applicable (voir les indications
+          sur les champs ci-dessus). La CEHR reste due au montant calculé sans
+          lissage :{" "}
+          <span className="font-semibold">
+            {fmtEur(result.cehrWithoutQuotient.total)}
+          </span>
+          .
+        </div>
+      )}
+
+      {result?.eligible && (
+        <Section title="Comparaison du calcul CEHR">
+          <div className="border rounded-md overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-100 text-left">
+                <tr>
+                  <th className="p-3 font-semibold">Élément</th>
+                  <th className="p-3 font-semibold text-right">
+                    Sans quotient
+                  </th>
+                  <th className="p-3 font-semibold text-right bg-green-50">
+                    Avec quotient
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                <tr>
+                  <td className="p-3 text-gray-600">
+                    <button
+                      type="button"
+                      onClick={() => setShowSteps((s) => !s)}
+                      className={classNames(
+                        "flex items-center gap-1",
+                        "hover:text-gray-900 cursor-pointer",
+                      )}
+                    >
+                      Base imposable
+                      {showSteps ? (
+                        <ChevronUpIcon className="h-3 w-3" />
+                      ) : (
+                        <ChevronDownIcon className="h-3 w-3" />
+                      )}
+                    </button>
+                  </td>
+                  <td className="p-3 text-right">{fmtEur(rfrN!)}</td>
+                  <td className="p-3 text-right bg-green-50">
+                    {fmtEur(midpoint)}
+                  </td>
+                </tr>
+                {showSteps && (
+                  <tr className="bg-gray-50">
+                    <td colSpan={3} className="p-4">
+                      <div className="text-xs text-gray-600 mb-2">
+                        Détail du calcul de la <strong>base lissée</strong>{" "}
+                        (colonne « Avec quotient ») :
+                      </div>
+                      <ol
+                        className={classNames(
+                          "list-decimal pl-6 space-y-1",
+                          "text-xs text-gray-700",
+                        )}
+                      >
+                        <li>
+                          Moyenne des deux années précédentes :{" "}
+                          <span className="font-mono">
+                            ({fmtEur(rfrNm2!)} + {fmtEur(rfrNm1!)}) / 2 ={" "}
+                            <strong>{fmtEur(result.averagePrevious)}</strong>
+                          </span>
+                        </li>
+                        <li>
+                          Fraction excédentaire :{" "}
+                          <span className="font-mono">
+                            {fmtEur(rfrN!)} − {fmtEur(result.averagePrevious)} ={" "}
+                            <strong>
+                              {fmtEur(rfrN! - result.averagePrevious)}
+                            </strong>
+                          </span>
+                        </li>
+                        <li>
+                          Fraction divisée par deux :{" "}
+                          <span className="font-mono">
+                            {fmtEur(rfrN! - result.averagePrevious)} / 2 ={" "}
+                            <strong>
+                              {fmtEur((rfrN! - result.averagePrevious) / 2)}
+                            </strong>
+                          </span>
+                        </li>
+                        <li>
+                          Base lissée :{" "}
+                          <span className="font-mono">
+                            {fmtEur(result.averagePrevious)} +{" "}
+                            {fmtEur((rfrN! - result.averagePrevious) / 2)} ={" "}
+                            <strong className="text-green-700">
+                              {fmtEur(midpoint)}
+                            </strong>
+                          </span>
+                        </li>
+                      </ol>
+                    </td>
+                  </tr>
+                )}
+                <tr>
+                  <td className="p-3 text-gray-600">Base 3 %</td>
+                  <td className="p-3 text-right">
+                    {fmtEur(result.cehrWithoutQuotient.base3)}
+                  </td>
+                  <td className="p-3 text-right bg-green-50">
+                    {fmtEur(midpointBreakdown.base3)}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 text-gray-600">Base 4 %</td>
+                  <td className="p-3 text-right">
+                    {fmtEur(result.cehrWithoutQuotient.base4)}
+                  </td>
+                  <td className="p-3 text-right bg-green-50">
+                    {fmtEur(midpointBreakdown.base4)}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 text-gray-600">
+                    CEHR à 3 %
+                    <span className="text-xs text-gray-400 ml-1">
+                      (× 2 quotient)
+                    </span>
+                  </td>
+                  <td className="p-3 text-right">
+                    {fmtEur(result.cehrWithoutQuotient.amount3)}
+                  </td>
+                  <td className="p-3 text-right bg-green-50">
+                    {fmtEur(midpointBreakdown.amount3 * 2)}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 text-gray-600">
+                    CEHR à 4 %
+                    <span className="text-xs text-gray-400 ml-1">
+                      (× 2 quotient)
+                    </span>
+                  </td>
+                  <td className="p-3 text-right">
+                    {fmtEur(result.cehrWithoutQuotient.amount4)}
+                  </td>
+                  <td className="p-3 text-right bg-green-50">
+                    {fmtEur(midpointBreakdown.amount4 * 2)}
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 font-semibold">CEHR totale</td>
+                  <td className="p-3 text-right font-semibold">
+                    {fmtEur(result.cehrWithoutQuotient.total)}
+                  </td>
+                  <td className="p-3 text-right font-semibold bg-green-100">
+                    {fmtEur(result.cehrWithQuotient)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div
+            className={classNames(
+              "mt-4 p-4 rounded-md",
+              "bg-green-100 border border-green-300",
+              "flex items-baseline justify-between flex-wrap gap-2",
+            )}
+          >
+            <span className="text-sm text-green-900">
+              Gain total grâce au lissage
+              <span className="text-xs text-green-700 ml-2">
+                (CEHR sans quotient − CEHR avec quotient)
+              </span>
+            </span>
+            <span className="text-xl font-bold text-green-700">
+              {fmtEur(result.savings)}
+            </span>
+          </div>
+        </Section>
+      )}
+
+      {result?.eligible && (
+        <Section title="Type de revenus exceptionnels concernés">
+          <p className="text-sm text-gray-600 mb-3">
+            Cochez les natures de revenus exceptionnels à mentionner dans le
+            courrier. Le texte d&apos;introduction et la liste des justificatifs
+            s&apos;adapteront automatiquement.
+          </p>
+          <div className="flex flex-col gap-2 max-w-3xl">
+            {Object.values(ASSET_DEFINITIONS).map((asset) => {
+              const checked = assetTypes.includes(asset.id);
+              return (
+                <label
+                  key={asset.id}
+                  className={classNames(
+                    "flex items-start gap-3 p-3 rounded-md border cursor-pointer",
+                    checked
+                      ? "border-blue-300 bg-blue-50"
+                      : "border-gray-200 hover:border-gray-300",
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleAsset(asset.id)}
+                    className="mt-0.5"
+                  />
+                  <div className="text-sm">
+                    <div className="font-medium">{asset.label}</div>
+                    <div className="text-xs text-gray-600 mt-0.5">
+                      Justificatifs : {asset.justificatifs.join(" · ")}
+                    </div>
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+          {assetTypes.length === 0 && (
+            <div className="mt-3 p-3 rounded-md bg-yellow-50 border border-yellow-200 text-sm text-yellow-900">
+              Cochez au moins un type de revenu exceptionnel pour générer le
+              courrier.
+            </div>
+          )}
+        </Section>
+      )}
+
+      {email && (
+        <Section
+          title="Email à envoyer au SIP"
+          actions={
+            <button
+              type="button"
+              onClick={onCopy}
+              className={classNames(
+                "flex items-center gap-2 px-3 py-1.5 rounded shadow text-sm font-semibold hover:opacity-75",
+                copied ? "bg-green-200" : "bg-blue-100",
+              )}
+            >
+              {copied ? (
+                <CheckIcon className="h-4 w-4" />
+              ) : (
+                <ClipboardIcon className="h-4 w-4" />
+              )}
+              {copied ? "Copié" : "Copier l'email"}
+            </button>
+          }
+        >
+          <textarea
+            readOnly
+            value={email}
+            className={classNames(
+              "w-full h-[28rem] font-mono text-xs",
+              "border rounded-md p-3 bg-white",
+            )}
+          />
+          <p className="text-xs text-gray-500 mt-2">
+            À déposer via la messagerie sécurisée impots.gouv.fr, rubrique «
+            J&apos;ai une question sur le calcul de mon impôt », après réception
+            de l&apos;avis d&apos;imposition. Joindre les justificatifs listés
+            en bas du courrier.
+          </p>
+        </Section>
+      )}
+
+      <Section title="Références">
+        <ul className="text-sm space-y-2 text-gray-700">
+          <li>
+            <strong>Article 223 sexies du Code Général des Impôts</strong> —
+            base légale de la CEHR et, à son V, du mécanisme de lissage via le
+            système du quotient. À rechercher sur{" "}
+            <a
+              href="https://www.legifrance.gouv.fr/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              legifrance.gouv.fr
+            </a>
+            .
+          </li>
+          <li>
+            <strong>BOFiP-Impôts</strong> — doctrine administrative officielle
+            sur la contribution exceptionnelle sur les hauts revenus. À
+            consulter sur{" "}
+            <a
+              href="https://bofip.impots.gouv.fr/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              bofip.impots.gouv.fr
+            </a>{" "}
+            (rechercher « contribution exceptionnelle hauts revenus »).
+          </li>
+          <li>
+            <a
+              href="https://prosper-conseil.fr/optimisation-fiscale/cehr-calcul-bareme-et-lissage/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+            >
+              Prosper Conseil — CEHR : calcul, barème et lissage
+            </a>{" "}
+            — synthèse pédagogique avec exemples chiffrés.
+          </li>
+        </ul>
+      </Section>
+    </div>
+  );
+}

--- a/app/cehr/page.tsx
+++ b/app/cehr/page.tsx
@@ -199,9 +199,9 @@ export default function CehrPage() {
           Puis-je réduire une partie de mes impôts ?
         </h1>
         <p className="text-sm text-gray-600 mt-2 max-w-3xl">
-          Si vous avez eu une année de revenus exceptionnellement élevée (vente
-          d&apos;actions, RSU, stock-options, prime ou indemnité importante),
-          vous avez peut-être payé une surtaxe appelée
+          Si vous avez eu une année de revenus exceptionnellement élevée à cause
+          de cessions d&apos;actions (RSU, ESPP ou stock-options), vous avez
+          peut-être payé une surtaxe appelée
           <strong>
             {" "}
             Contribution Exceptionnelle sur les Hauts Revenus (CEHR)

--- a/app/cehr/page.tsx
+++ b/app/cehr/page.tsx
@@ -1,90 +1,19 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import classNames from "classnames";
-import toast from "react-hot-toast";
-import {
-  ClipboardIcon,
-  CheckIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-} from "@heroicons/react/24/solid";
-import { NumberInput } from "@/components/ui/Field";
-import { Section } from "@/components/ui/Section";
-import {
-  cehrEntryThreshold,
-  computeCehr,
-  computeQuotient,
-  evaluateFieldStatus,
-  type FoyerSituation,
-} from "@/lib/taxes/cehr";
-import {
-  ASSET_DEFINITIONS,
-  buildCehrEmail,
-  type AssetType,
-} from "@/lib/taxes/cehr-template";
-
-const fmtEur = (n: number): string =>
-  `${Math.round(n).toLocaleString("fr-FR")} €`;
+import { useState } from "react";
+import { fmtEur, type FoyerSituation } from "@/lib/taxes/cehr";
+import { type AssetType } from "@/lib/taxes/cehr-template";
+import { Header } from "./_Header";
+import { EligibilityInputs } from "./_EligibilityInputs";
+import { CehrComparisonTable } from "./_CehrComparisonTable";
+import { AssetTypeSelector } from "./_AssetTypeSelector";
+import { EmailPreview } from "./_EmailPreview";
+import { References } from "./_References";
+import { useCehrCalculator } from "./_useCehrCalculator";
 
 const CURRENT_YEAR = new Date().getFullYear();
 const YEAR_OPTIONS = Array.from({ length: 10 }, (_, i) => CURRENT_YEAR - i).map(
   (y) => ({ label: String(y), value: y }),
-);
-
-const SITUATION_OPTIONS: Array<{ label: string; value: FoyerSituation }> = [
-  { label: "Couple (marié·e / pacsé·e)", value: "couple" },
-  { label: "Célibataire / divorcé·e / veuf·ve", value: "single" },
-];
-
-type CheckStatus = "neutral" | "passed" | "failed";
-
-interface RfrFieldProps {
-  label: React.ReactNode;
-  explanation: React.ReactNode;
-  value: number | null;
-  onChange: (v: number | null) => void;
-  placeholder?: string;
-  status: CheckStatus;
-  checkDetail?: string;
-}
-
-const RfrField = ({
-  label,
-  explanation,
-  value,
-  onChange,
-  placeholder,
-  status,
-  checkDetail,
-}: RfrFieldProps) => (
-  <div
-    className={classNames(
-      "border rounded-md p-4 max-w-3xl",
-      status === "passed" && "border-green-300 bg-green-50/40",
-      status === "failed" && "border-red-300 bg-red-50/40",
-      status === "neutral" && "border-gray-200 bg-white",
-    )}
-  >
-    <div className="flex items-center gap-2 text-sm font-semibold mb-1">
-      {label}
-      {status === "passed" && (
-        <CheckCircleIcon className="h-4 w-4 text-green-600" />
-      )}
-      {status === "failed" && <XCircleIcon className="h-4 w-4 text-red-600" />}
-    </div>
-    <div className="text-xs text-gray-600 mb-3">{explanation}</div>
-    <NumberInput
-      value={value}
-      onChange={(v) => onChange(Number.isNaN(v) ? null : v)}
-      min={0}
-      maxDecimals={0}
-      placeholder={placeholder}
-      validationError={status === "failed" ? checkDetail : null}
-    />
-  </div>
 );
 
 export default function CehrPage() {
@@ -101,545 +30,64 @@ export default function CehrPage() {
     );
   };
 
-  const allFilled = rfrN !== null && rfrNm1 !== null && rfrNm2 !== null;
-  const entryThreshold = cehrEntryThreshold(situation);
-
-  const statusNm1 = evaluateFieldStatus({
+  const view = useCehrCalculator({
+    yearN,
+    situation,
     rfrN,
     rfrNm1,
     rfrNm2,
-    situation,
-    field: "Nm1",
+    assetTypes,
   });
-  const detailNm1 =
-    statusNm1 === "failed" && rfrNm1 !== null
-      ? `RFR N-1 = ${fmtEur(rfrNm1)} ≥ ${fmtEur(entryThreshold)}`
-      : undefined;
-
-  const statusNm2 = evaluateFieldStatus({
-    rfrN,
-    rfrNm1,
-    rfrNm2,
-    situation,
-    field: "Nm2",
-  });
-  const detailNm2 =
-    statusNm2 === "failed" && rfrNm2 !== null
-      ? `RFR N-2 = ${fmtEur(rfrNm2)} ≥ ${fmtEur(entryThreshold)}`
-      : undefined;
-
-  const statusN = evaluateFieldStatus({
-    rfrN,
-    rfrNm1,
-    rfrNm2,
-    situation,
-    field: "N",
-  });
-  const detailN = (() => {
-    if (statusN !== "failed" || rfrN === null) return undefined;
-    if (rfrN <= entryThreshold) {
-      return `RFR N = ${fmtEur(rfrN)} ≤ ${fmtEur(
-        entryThreshold,
-      )} (seuil CEHR) — aucune CEHR n'est due, le lissage est sans objet.`;
-    }
-    if (rfrNm1 !== null && rfrNm2 !== null) {
-      return `RFR N = ${fmtEur(rfrN)} < 1,5 × moyenne (${fmtEur(
-        1.5 * ((rfrNm1 + rfrNm2) / 2),
-      )})`;
-    }
-    return undefined;
-  })();
-
-  const result = useMemo(() => {
-    if (!allFilled) return null;
-    return computeQuotient({
-      rfrN: rfrN!,
-      rfrNm1: rfrNm1!,
-      rfrNm2: rfrNm2!,
-      situation,
-    });
-  }, [allFilled, rfrN, rfrNm1, rfrNm2, situation]);
-
-  const midpoint = result
-    ? result.averagePrevious + (rfrN! - result.averagePrevious) / 2
-    : 0;
-  const midpointBreakdown = result
-    ? computeCehr(midpoint, situation)
-    : { rfr: 0, base3: 0, base4: 0, amount3: 0, amount4: 0, total: 0 };
-
-  const email = useMemo(() => {
-    if (!result || !allFilled || !result.eligible || assetTypes.length === 0) {
-      return "";
-    }
-    return buildCehrEmail({
-      yearN,
-      rfrN: rfrN!,
-      rfrNm1: rfrNm1!,
-      rfrNm2: rfrNm2!,
-      quotient: result,
-      assetTypes,
-      situation,
-    });
-  }, [result, allFilled, yearN, rfrN, rfrNm1, rfrNm2, assetTypes, situation]);
-
-  const [showSteps, setShowSteps] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const onCopy = () => {
-    if (!email) return;
-    navigator.clipboard.writeText(email);
-    setCopied(true);
-    toast.success("Email copié dans le presse-papier");
-    setTimeout(() => setCopied(false), 1500);
-  };
 
   return (
     <div className="flex flex-col gap-8 px-4">
-      <header>
-        <h1 className="text-3xl font-semibold">
-          Puis-je réduire une partie de mes impôts ?
-        </h1>
-        <p className="text-sm text-gray-600 mt-3 max-w-3xl">
-          Une année avec beaucoup de cessions d&apos;actions (RSU, ESPP,
-          stock-options) peut déclencher la{" "}
-          <strong>
-            Contribution Exceptionnelle sur les Hauts Revenus (CEHR)
-          </strong>
-          , une surtaxe de 3 à 4 % qui s&apos;applique au-delà d&apos;un certain
-          seuil de revenu fiscal de référence. Le code des impôts prévoit un
-          mécanisme de lissage qui ramène la base de calcul à un niveau plus
-          proche de la moyenne de vos années précédentes — ce qui peut
-          sérieusement réduire la facture.
-        </p>
-        <p className="text-sm text-gray-600 mt-3 max-w-3xl">
-          Ce lissage est censé être appliqué automatiquement, mais il arrive que
-          le SIP l&apos;oublie. Et si votre situation familiale a changé sur la
-          période (mariage, PACS, divorce, décès), c&apos;est à vous de faire la
-          démarche pour fournir les bons revenus de référence.
-        </p>
-        <p className="text-sm text-gray-600 mt-3 max-w-3xl">
-          Cet outil estime ce que votre CEHR <em>devrait</em> être avec lissage,
-          et génère le courrier de réclamation à envoyer aux impôts si
-          nécessaire.
-        </p>
-      </header>
+      <Header />
 
-      <Section title="Vos informations">
-        <div className="flex flex-col gap-4">
-          <div>
-            <div className="text-sm font-medium mb-2">Situation familiale</div>
-            <div className="inline-flex rounded-md shadow-sm border border-gray-300 overflow-hidden">
-              {SITUATION_OPTIONS.map((opt, idx) => {
-                const active = situation === opt.value;
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => setSituation(opt.value)}
-                    className={classNames(
-                      "px-4 py-1.5 text-sm transition-colors",
-                      idx > 0 && "border-l border-gray-300",
-                      active
-                        ? "bg-gray-100 text-gray-900 font-bold"
-                        : "bg-white text-gray-600 hover:bg-gray-50",
-                    )}
-                  >
-                    {opt.label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
+      <EligibilityInputs
+        yearN={yearN}
+        yearOptions={YEAR_OPTIONS}
+        situation={situation}
+        rfrN={rfrN}
+        rfrNm1={rfrNm1}
+        rfrNm2={rfrNm2}
+        view={view}
+        onYearChange={setYearN}
+        onSituationChange={setSituation}
+        onRfrNChange={setRfrN}
+        onRfrNm1Change={setRfrNm1}
+        onRfrNm2Change={setRfrNm2}
+      />
 
-          <RfrField
-            label={
-              <span className="flex items-center gap-2 flex-wrap">
-                <span>RFR de l&apos;année concernée</span>
-                <span className="flex items-center gap-1">
-                  <span className="text-xs font-normal text-gray-500">
-                    année :
-                  </span>
-                  <select
-                    value={String(yearN)}
-                    onChange={(e) => setYearN(Number(e.target.value))}
-                    className={classNames(
-                      "bg-transparent border rounded px-2 py-0.5",
-                      "text-sm font-semibold border-gray-300",
-                      "hover:border-gray-400 focus:outline-none",
-                      "cursor-pointer",
-                    )}
-                  >
-                    {YEAR_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={String(opt.value)}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                </span>
-              </span>
-            }
-            explanation={
-              <>
-                Le revenu fiscal de référence de l&apos;année concernée (celle
-                de l&apos;avis d&apos;imposition que vous contestez) doit être{" "}
-                <strong>au moins 1,5 fois</strong> la moyenne des RFR des deux
-                années précédentes. C&apos;est l&apos;écart de revenu qui ouvre
-                droit au lissage.
-              </>
-            }
-            value={rfrN}
-            onChange={setRfrN}
-            placeholder="ex. 800 000"
-            status={statusN}
-            checkDetail={detailN}
-          />
-
-          <RfrField
-            label={`RFR ${yearN - 1} (N-1)`}
-            explanation={
-              <>
-                Le RFR de l&apos;année précédant l&apos;année concernée doit
-                être <strong>inférieur ou égal</strong> au seuil d&apos;entrée
-                de la CEHR (
-                <strong>{fmtEur(cehrEntryThreshold(situation))}</strong> pour la
-                situation choisie). Si vous étiez déjà soumis à la CEHR cette
-                année-là, le lissage n&apos;est pas applicable.
-              </>
-            }
-            value={rfrNm1}
-            onChange={setRfrNm1}
-            placeholder="ex. 100 000"
-            status={statusNm1}
-            checkDetail={detailNm1}
-          />
-
-          <RfrField
-            label={`RFR ${yearN - 2} (N-2)`}
-            explanation={
-              <>
-                Même condition deux ans en arrière : le RFR doit être{" "}
-                <strong>inférieur ou égal</strong> à{" "}
-                <strong>{fmtEur(cehrEntryThreshold(situation))}</strong>. Les
-                deux années antérieures doivent être hors-CEHR pour que le
-                revenu de l&apos;année N soit considéré comme exceptionnel par
-                l&apos;article 223 sexies V du CGI.
-              </>
-            }
-            value={rfrNm2}
-            onChange={setRfrNm2}
-            placeholder="ex. 200 000"
-            status={statusNm2}
-            checkDetail={detailNm2}
-          />
-        </div>
-      </Section>
-
-      {result && !result.eligible && (
+      {view.result && !view.result.eligible && (
         <div className="p-3 rounded-md bg-yellow-50 text-sm border border-yellow-200">
           Le système du quotient n&apos;est pas applicable (voir les indications
           sur les champs ci-dessus). La CEHR reste due au montant calculé sans
           lissage :{" "}
           <span className="font-semibold">
-            {fmtEur(result.cehrWithoutQuotient.total)}
+            {fmtEur(view.result.cehrWithoutQuotient.total)}
           </span>
           .
         </div>
       )}
 
-      {result?.eligible && (
-        <Section title="Comparaison du calcul CEHR">
-          <div className="border rounded-md overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-100 text-left">
-                <tr>
-                  <th className="p-3 font-semibold">Élément</th>
-                  <th className="p-3 font-semibold text-right">
-                    Sans quotient
-                  </th>
-                  <th className="p-3 font-semibold text-right bg-green-50">
-                    Avec quotient
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                <tr>
-                  <td className="p-3 text-gray-600">
-                    <button
-                      type="button"
-                      onClick={() => setShowSteps((s) => !s)}
-                      className={classNames(
-                        "flex items-center gap-1",
-                        "hover:text-gray-900 cursor-pointer",
-                      )}
-                    >
-                      Base imposable
-                      {showSteps ? (
-                        <ChevronUpIcon className="h-3 w-3" />
-                      ) : (
-                        <ChevronDownIcon className="h-3 w-3" />
-                      )}
-                    </button>
-                  </td>
-                  <td className="p-3 text-right">{fmtEur(rfrN!)}</td>
-                  <td className="p-3 text-right bg-green-50">
-                    {fmtEur(midpoint)}
-                  </td>
-                </tr>
-                {showSteps && (
-                  <tr className="bg-gray-50">
-                    <td colSpan={3} className="p-4">
-                      <div className="text-xs text-gray-600 mb-2">
-                        Détail du calcul de la <strong>base lissée</strong>{" "}
-                        (colonne « Avec quotient ») :
-                      </div>
-                      <ol
-                        className={classNames(
-                          "list-decimal pl-6 space-y-1",
-                          "text-xs text-gray-700",
-                        )}
-                      >
-                        <li>
-                          Moyenne des deux années précédentes :{" "}
-                          <span className="font-mono">
-                            ({fmtEur(rfrNm2!)} + {fmtEur(rfrNm1!)}) / 2 ={" "}
-                            <strong>{fmtEur(result.averagePrevious)}</strong>
-                          </span>
-                        </li>
-                        <li>
-                          Fraction excédentaire :{" "}
-                          <span className="font-mono">
-                            {fmtEur(rfrN!)} − {fmtEur(result.averagePrevious)} ={" "}
-                            <strong>
-                              {fmtEur(rfrN! - result.averagePrevious)}
-                            </strong>
-                          </span>
-                        </li>
-                        <li>
-                          Fraction divisée par deux :{" "}
-                          <span className="font-mono">
-                            {fmtEur(rfrN! - result.averagePrevious)} / 2 ={" "}
-                            <strong>
-                              {fmtEur((rfrN! - result.averagePrevious) / 2)}
-                            </strong>
-                          </span>
-                        </li>
-                        <li>
-                          Base lissée :{" "}
-                          <span className="font-mono">
-                            {fmtEur(result.averagePrevious)} +{" "}
-                            {fmtEur((rfrN! - result.averagePrevious) / 2)} ={" "}
-                            <strong className="text-green-700">
-                              {fmtEur(midpoint)}
-                            </strong>
-                          </span>
-                        </li>
-                      </ol>
-                    </td>
-                  </tr>
-                )}
-                <tr>
-                  <td className="p-3 text-gray-600">Base 3 %</td>
-                  <td className="p-3 text-right">
-                    {fmtEur(result.cehrWithoutQuotient.base3)}
-                  </td>
-                  <td className="p-3 text-right bg-green-50">
-                    {fmtEur(midpointBreakdown.base3)}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="p-3 text-gray-600">Base 4 %</td>
-                  <td className="p-3 text-right">
-                    {fmtEur(result.cehrWithoutQuotient.base4)}
-                  </td>
-                  <td className="p-3 text-right bg-green-50">
-                    {fmtEur(midpointBreakdown.base4)}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="p-3 text-gray-600">
-                    CEHR à 3 %
-                    <span className="text-xs text-gray-400 ml-1">
-                      (× 2 quotient)
-                    </span>
-                  </td>
-                  <td className="p-3 text-right">
-                    {fmtEur(result.cehrWithoutQuotient.amount3)}
-                  </td>
-                  <td className="p-3 text-right bg-green-50">
-                    {fmtEur(midpointBreakdown.amount3 * 2)}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="p-3 text-gray-600">
-                    CEHR à 4 %
-                    <span className="text-xs text-gray-400 ml-1">
-                      (× 2 quotient)
-                    </span>
-                  </td>
-                  <td className="p-3 text-right">
-                    {fmtEur(result.cehrWithoutQuotient.amount4)}
-                  </td>
-                  <td className="p-3 text-right bg-green-50">
-                    {fmtEur(midpointBreakdown.amount4 * 2)}
-                  </td>
-                </tr>
-                <tr className="bg-gray-50">
-                  <td className="p-3 font-semibold">CEHR totale</td>
-                  <td className="p-3 text-right font-semibold">
-                    {fmtEur(result.cehrWithoutQuotient.total)}
-                  </td>
-                  <td className="p-3 text-right font-semibold bg-green-100">
-                    {fmtEur(result.cehrWithQuotient)}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div
-            className={classNames(
-              "mt-4 p-4 rounded-md",
-              "bg-green-100 border border-green-300",
-              "flex items-baseline justify-between flex-wrap gap-2",
-            )}
-          >
-            <span className="text-sm text-green-900">
-              Gain total grâce au lissage
-              <span className="text-xs text-green-700 ml-2">
-                (CEHR sans quotient − CEHR avec quotient)
-              </span>
-            </span>
-            <span className="text-xl font-bold text-green-700">
-              {fmtEur(result.savings)}
-            </span>
-          </div>
-        </Section>
+      {view.result?.eligible && (
+        <CehrComparisonTable
+          result={view.result}
+          rfrN={rfrN!}
+          rfrNm1={rfrNm1!}
+          rfrNm2={rfrNm2!}
+          midpoint={view.midpoint}
+          midpointBreakdown={view.midpointBreakdown}
+        />
       )}
 
-      {result?.eligible && (
-        <Section title="Type de revenus exceptionnels concernés">
-          <p className="text-sm text-gray-600 mb-3">
-            Cochez les natures de revenus exceptionnels à mentionner dans le
-            courrier. Le texte d&apos;introduction et la liste des justificatifs
-            s&apos;adapteront automatiquement.
-          </p>
-          <div className="flex flex-col gap-2 max-w-3xl">
-            {Object.values(ASSET_DEFINITIONS).map((asset) => {
-              const checked = assetTypes.includes(asset.id);
-              return (
-                <label
-                  key={asset.id}
-                  className={classNames(
-                    "flex items-start gap-3 p-3 rounded-md border cursor-pointer",
-                    checked
-                      ? "border-blue-300 bg-blue-50"
-                      : "border-gray-200 hover:border-gray-300",
-                  )}
-                >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => toggleAsset(asset.id)}
-                    className="mt-0.5"
-                  />
-                  <div className="text-sm">
-                    <div className="font-medium">{asset.label}</div>
-                    <div className="text-xs text-gray-600 mt-0.5">
-                      Justificatifs : {asset.justificatifs.join(" · ")}
-                    </div>
-                  </div>
-                </label>
-              );
-            })}
-          </div>
-          {assetTypes.length === 0 && (
-            <div className="mt-3 p-3 rounded-md bg-yellow-50 border border-yellow-200 text-sm text-yellow-900">
-              Cochez au moins un type de revenu exceptionnel pour générer le
-              courrier.
-            </div>
-          )}
-        </Section>
+      {view.result?.eligible && (
+        <AssetTypeSelector assetTypes={assetTypes} onToggle={toggleAsset} />
       )}
 
-      {email && (
-        <Section
-          title="Email à envoyer au SIP"
-          actions={
-            <button
-              type="button"
-              onClick={onCopy}
-              className={classNames(
-                "flex items-center gap-2 px-3 py-1.5 rounded shadow text-sm font-semibold hover:opacity-75",
-                copied ? "bg-green-200" : "bg-blue-100",
-              )}
-            >
-              {copied ? (
-                <CheckIcon className="h-4 w-4" />
-              ) : (
-                <ClipboardIcon className="h-4 w-4" />
-              )}
-              {copied ? "Copié" : "Copier l'email"}
-            </button>
-          }
-        >
-          <textarea
-            readOnly
-            value={email}
-            className={classNames(
-              "w-full h-[28rem] font-mono text-xs",
-              "border rounded-md p-3 bg-white",
-            )}
-          />
-          <p className="text-xs text-gray-500 mt-2">
-            À déposer via la messagerie sécurisée impots.gouv.fr, rubrique «
-            J&apos;ai une question sur le calcul de mon impôt », après réception
-            de l&apos;avis d&apos;imposition. Joindre les justificatifs listés
-            en bas du courrier.
-          </p>
-        </Section>
-      )}
+      {view.email && <EmailPreview email={view.email} />}
 
-      <Section title="Références">
-        <ul className="text-sm space-y-2 text-gray-700">
-          <li>
-            <a
-              href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036427364"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:underline"
-            >
-              Article 223 sexies du Code Général des Impôts (Légifrance)
-            </a>{" "}
-            — base légale de la CEHR (I) et du mécanisme de lissage (II.1). Le
-            II.2 précise le cas spécifique d&apos;une modification de la
-            situation familiale, pour lequel le dépôt d&apos;une réclamation est
-            explicitement requis.
-          </li>
-          <li>
-            <a
-              href="https://bofip.impots.gouv.fr/bofip/7804-PGP.html/identifiant=BOI-IR-CHR-20170711"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:underline"
-            >
-              BOI-IR-CHR — Contribution exceptionnelle sur les hauts revenus
-              (BOFiP)
-            </a>{" "}
-            — doctrine administrative officielle de la DGFiP : champ
-            d&apos;application, calcul, mécanisme de lissage et procédure de
-            réclamation.
-          </li>
-          <li>
-            <a
-              href="https://prosper-conseil.fr/optimisation-fiscale/cehr-calcul-bareme-et-lissage/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:underline"
-            >
-              Prosper Conseil — CEHR : calcul, barème et lissage
-            </a>{" "}
-            — synthèse pédagogique avec exemples chiffrés.
-          </li>
-        </ul>
-      </Section>
+      <References />
     </div>
   );
 }

--- a/app/cehr/page.tsx
+++ b/app/cehr/page.tsx
@@ -198,19 +198,28 @@ export default function CehrPage() {
         <h1 className="text-3xl font-semibold">
           Puis-je réduire une partie de mes impôts ?
         </h1>
-        <p className="text-sm text-gray-600 mt-2 max-w-3xl">
-          Si vous avez eu une année de revenus exceptionnellement élevée à cause
-          de cessions d&apos;actions (RSU, ESPP ou stock-options), vous avez
-          peut-être payé une surtaxe appelée
+        <p className="text-sm text-gray-600 mt-3 max-w-3xl">
+          Une année avec beaucoup de cessions d&apos;actions (RSU, ESPP,
+          stock-options) peut déclencher la{" "}
           <strong>
-            {" "}
             Contribution Exceptionnelle sur les Hauts Revenus (CEHR)
           </strong>
-          . La loi prévoit un mécanisme de « lissage » qui permet de la
-          recalculer en tenant compte de vos revenus des deux années précédentes
-          — et donc, souvent, de la réduire fortement. Cet outil vérifie si vous
-          y avez droit, calcule l&apos;économie potentielle, et génère le
-          courrier de réclamation à envoyer aux impôts.
+          , une surtaxe de 3 à 4 % qui s&apos;applique au-delà d&apos;un certain
+          seuil de revenu fiscal de référence. Le code des impôts prévoit un
+          mécanisme de lissage qui ramène la base de calcul à un niveau plus
+          proche de la moyenne de vos années précédentes — ce qui peut
+          sérieusement réduire la facture.
+        </p>
+        <p className="text-sm text-gray-600 mt-3 max-w-3xl">
+          Ce lissage est censé être appliqué automatiquement, mais il arrive que
+          le SIP l&apos;oublie. Et si votre situation familiale a changé sur la
+          période (mariage, PACS, divorce, décès), c&apos;est à vous de faire la
+          démarche pour fournir les bons revenus de référence.
+        </p>
+        <p className="text-sm text-gray-600 mt-3 max-w-3xl">
+          Cet outil estime ce que votre CEHR <em>devrait</em> être avec lissage,
+          et génère le courrier de réclamation à envoyer aux impôts si
+          nécessaire.
         </p>
       </header>
 
@@ -218,13 +227,6 @@ export default function CehrPage() {
         <div className="flex flex-col gap-4">
           <div>
             <div className="text-sm font-medium mb-2">Situation familiale</div>
-            <div className="text-xs text-gray-500 mb-2 max-w-3xl">
-              Cet outil suppose que la situation familiale est restée identique
-              sur les trois années (N-2, N-1, N). Si elle a changé (mariage,
-              PACS, divorce, décès), les seuils CEHR applicables aux RFR
-              antérieurs peuvent différer — vérifiez manuellement avant
-              d&apos;envoyer le courrier.
-            </div>
             <div className="inline-flex rounded-md shadow-sm border border-gray-300 overflow-hidden">
               {SITUATION_OPTIONS.map((opt, idx) => {
                 const active = situation === opt.value;
@@ -598,32 +600,32 @@ export default function CehrPage() {
       <Section title="Références">
         <ul className="text-sm space-y-2 text-gray-700">
           <li>
-            <strong>Article 223 sexies du Code Général des Impôts</strong> —
-            base légale de la CEHR et, à son V, du mécanisme de lissage via le
-            système du quotient. À rechercher sur{" "}
             <a
-              href="https://www.legifrance.gouv.fr/"
+              href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000036427364"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline"
             >
-              legifrance.gouv.fr
-            </a>
-            .
+              Article 223 sexies du Code Général des Impôts (Légifrance)
+            </a>{" "}
+            — base légale de la CEHR (I) et du mécanisme de lissage (II.1). Le
+            II.2 précise le cas spécifique d&apos;une modification de la
+            situation familiale, pour lequel le dépôt d&apos;une réclamation est
+            explicitement requis.
           </li>
           <li>
-            <strong>BOFiP-Impôts</strong> — doctrine administrative officielle
-            sur la contribution exceptionnelle sur les hauts revenus. À
-            consulter sur{" "}
             <a
-              href="https://bofip.impots.gouv.fr/"
+              href="https://bofip.impots.gouv.fr/bofip/7804-PGP.html/identifiant=BOI-IR-CHR-20170711"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 hover:underline"
             >
-              bofip.impots.gouv.fr
+              BOI-IR-CHR — Contribution exceptionnelle sur les hauts revenus
+              (BOFiP)
             </a>{" "}
-            (rechercher « contribution exceptionnelle hauts revenus »).
+            — doctrine administrative officielle de la DGFiP : champ
+            d&apos;application, calcul, mécanisme de lissage et procédure de
+            réclamation.
           </li>
           <li>
             <a

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,18 +4,11 @@
 
 :root {
   --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  background: #ffffff;
 }
 
 @layer utilities {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import Link from "next/link";
+import PageLink from "@/components/ui/PageLink";
 
 export default function Home() {
   return (
@@ -10,24 +10,10 @@ export default function Home() {
     >
       <header className="text-4xl font-semibold">Tax Helper</header>
       <div className="flex flex-col w-96 mx-auto items-stretch text-center gap-10">
-        <Link
-          className={`
-          bg-green-200 px-12 py-4 rounded shadow
-          hover:opacity-75 text-base font-semibold
-        `}
-          href="/report"
-        >
-          Compute my French tax report
-        </Link>
-        <Link
-          className={`
-          bg-blue-200 px-12 py-4 rounded shadow
-          hover:opacity-75 text-base font-semibold
-        `}
-          href="/cehr"
-        >
+        <PageLink href="/report">Compute my French tax report</PageLink>
+        <PageLink href="/cehr" color="blue">
           Lissage CEHR (système du quotient)
-        </Link>
+        </PageLink>
       </div>
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,12 +12,21 @@ export default function Home() {
       <div className="flex flex-col w-96 mx-auto items-stretch text-center gap-10">
         <Link
           className={`
-          bg-green-200 px-12 py-4 rounded shadow 
+          bg-green-200 px-12 py-4 rounded shadow
           hover:opacity-75 text-base font-semibold
         `}
           href="/report"
         >
           Compute my French tax report
+        </Link>
+        <Link
+          className={`
+          bg-blue-200 px-12 py-4 rounded shadow
+          hover:opacity-75 text-base font-semibold
+        `}
+          href="/cehr"
+        >
+          Lissage CEHR (système du quotient)
         </Link>
       </div>
     </main>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -7,7 +7,7 @@ interface ButtonProps {
   isDisabled?: boolean;
   label?: string;
   onClick: () => void;
-  color?: "green" | "red";
+  color?: "green" | "red" | "blue" | "softGreen";
 }
 
 export const Button = ({
@@ -26,6 +26,8 @@ export const Button = ({
       {
         "rounded shadow px-3 py-1.5": !isBorderless,
         "bg-green-200 text-base": color === "green",
+        "bg-blue-100": color === "blue",
+        "bg-green-200": color === "softGreen",
         "bg-red-400 text-white": color === "red",
       },
     )}

--- a/components/ui/ButtonGroup.tsx
+++ b/components/ui/ButtonGroup.tsx
@@ -9,15 +9,20 @@ export interface Option<V extends string> {
 interface ButtonGroupProps<V extends string> {
   onClick: (value: V) => void;
   options: ReadonlyArray<Option<V>>;
+  value?: V;
+  variant?: "default" | "segmented";
 }
 
 export const ButtonGroup = <V extends string>({
   onClick,
   options,
+  value,
+  variant = "default",
 }: ButtonGroupProps<V>) => {
   const [activeOption, setActiveOption] = useState<V | undefined>(
     options.at(0)?.value,
   );
+  const selectedOption = value ?? activeOption;
 
   if (options.length < 2) {
     throw Error(
@@ -25,26 +30,43 @@ export const ButtonGroup = <V extends string>({
     );
   }
   return (
-    <div className="inline-flex rounded-md shadow-xs" role="group">
+    <div
+      className={classNames(
+        "inline-flex",
+        variant === "default" && "rounded-md shadow-xs",
+        variant === "segmented" &&
+          "rounded-md shadow-sm border border-gray-300 overflow-hidden",
+      )}
+      role="group"
+    >
       {options.map((option, idx) => (
         <button
           key={option.label}
           type="button"
           className={classNames(
-            "shadow px-3 py-1.5 text-sm",
-            "bg-green-200 text-base",
-            "hover:opacity-75",
-            {
-              "rounded-s-lg": idx === 0,
-              "rounded-e-lg": idx === options.length - 1,
-              "font-semibold": option.value === activeOption,
-            },
+            variant === "default" && [
+              "shadow px-3 py-1.5 text-sm",
+              "bg-green-200 text-base",
+              "hover:opacity-75",
+              {
+                "rounded-s-lg": idx === 0,
+                "rounded-e-lg": idx === options.length - 1,
+                "font-semibold": option.value === selectedOption,
+              },
+            ],
+            variant === "segmented" && [
+              "px-4 py-1.5 text-sm transition-colors",
+              idx > 0 && "border-l border-gray-300",
+              option.value === selectedOption
+                ? "bg-gray-100 text-gray-900 font-bold"
+                : "bg-white text-gray-600 hover:bg-gray-50",
+            ],
           )}
           onClick={() => {
             setActiveOption(option.value);
             onClick(option.value);
           }}
-          disabled={option.value === activeOption}
+          disabled={variant === "default" && option.value === selectedOption}
         >
           {option.label}
         </button>

--- a/components/ui/Link.tsx
+++ b/components/ui/Link.tsx
@@ -4,10 +4,22 @@ interface LinkProps {
   children: ReactNode;
   href: string;
   isExternal?: boolean;
+  variant?: "default" | "blue";
 }
 
-export const Link = ({ href, children, isExternal }: LinkProps) => (
-  <span className="text-black font-semibold hover:opacity-75">
+export const Link = ({
+  href,
+  children,
+  isExternal,
+  variant = "default",
+}: LinkProps) => (
+  <span
+    className={
+      variant === "blue"
+        ? "text-blue-600 hover:underline"
+        : "text-black font-semibold hover:opacity-75"
+    }
+  >
     <a
       href={href}
       target={isExternal ? "_blank" : undefined}

--- a/components/ui/PageLink.tsx
+++ b/components/ui/PageLink.tsx
@@ -2,15 +2,18 @@ import Link from "next/link";
 
 export default function PageLink({
   children,
+  color = "green",
   href,
 }: {
   children: React.ReactNode;
+  color?: "blue" | "green";
   href: string;
 }) {
   return (
     <Link
       className={`
-        bg-green-200 px-12 py-4 rounded shadow 
+        ${color === "green" ? "bg-green-200" : "bg-blue-200"}
+        px-12 py-4 rounded shadow
         hover:opacity-75 text-base font-semibold
       `}
       href={{ pathname: href }}

--- a/lib/taxes/cehr-template.ts
+++ b/lib/taxes/cehr-template.ts
@@ -1,13 +1,11 @@
-import { fmtEur, type QuotientResult } from "./cehr";
+import { computeCehr, fmtEur, type QuotientResult } from "./cehr";
 
 export type AssetType = "rsu" | "espp" | "so";
 
 export interface AssetDefinition {
   id: AssetType;
   label: string;
-  // Short phrase used inside the intro sentence after "cessions de"
   intro: string;
-  // Asset-specific supporting documents
   justificatifs: string[];
 }
 
@@ -57,9 +55,8 @@ interface TemplateInputs {
 }
 
 const joinFr = (items: string[]): string => {
-  if (items.length === 0) return "";
-  if (items.length === 1) return items[0];
-  return `${items.slice(0, -1).join(", ")} et ${items[items.length - 1]}`;
+  if (items.length <= 1) return items[0] ?? "";
+  return `${items.slice(0, -1).join(", ")} et ${items.at(-1)}`;
 };
 
 export const buildCehrEmail = ({
@@ -80,6 +77,11 @@ export const buildCehrEmail = ({
   const yearNm1 = yearN - 1;
   const yearNm2 = yearN - 2;
   const c = quotient.cehrWithoutQuotient;
+  const excess = rfrN - quotient.averagePrevious;
+  const halfExcess = excess / 2;
+  const midpoint = quotient.averagePrevious + halfExcess;
+  const lissed = computeCehr(midpoint, situation);
+  const threshold150 = 1.5 * quotient.averagePrevious;
 
   const introPhrases = joinFr(
     assetTypes.map((t) => ASSET_DEFINITIONS[t].intro),
@@ -89,53 +91,71 @@ export const buildCehrEmail = ({
   );
 
   const isCouple = situation === "couple";
-  const p = (we: string, i: string): string => (isCouple ? we : i);
+  const p = (coupleText: string, singleText: string): string =>
+    isCouple ? coupleText : singleText;
 
-  const signatureLines = isCouple
-    ? [
-        "[Nom(s)]",
-        "Numéro fiscal déclarant 1 : [XX XX XXX XXX XXX]",
-        "Numéro fiscal déclarant 2 : [XX XX XXX XXX XXX]",
-      ]
-    : ["[Nom]", "Numéro fiscal : [XX XX XXX XXX XXX]"];
+  const signature = isCouple
+    ? "[Nom(s)]\nNuméro fiscal déclarant 1 : [XX XX XXX XXX XXX]\nNuméro fiscal déclarant 2 : [XX XX XXX XXX XXX]"
+    : "[Nom]\nNuméro fiscal : [XX XX XXX XXX XXX]";
 
-  return `Objet : Demande de lissage de la Contribution Exceptionnelle sur les Hauts Revenus — application du système du quotient — Revenus ${yearN}
+  return `Objet : Réclamation contentieuse — application du mécanisme de quotient prévu à l'article 223 sexies II du CGI — CEHR sur les revenus ${yearN}
 
 Madame, Monsieur,
 
-${p("Nous revenons", "Je reviens")} vers vous suite à la réception de ${p("notre", "mon")} avis d'imposition des revenus ${yearN} établi en ${yearNp1}.
+${p("Nous vous adressons", "Je vous adresse")} une réclamation concernant la Contribution Exceptionnelle sur les Hauts Revenus (CEHR) établie au titre des revenus ${yearN}, sur l'avis d'impôt émis en ${yearNp1}.
 
-Compte tenu de ${p("notre", "mon")} revenu fiscal de référence (RFR) ${yearN}, ${p("nous avons", "j'ai")} été soumis${isCouple ? "" : "·e"} à la Contribution Exceptionnelle sur les Hauts Revenus. Cependant, ${p("nos", "mes")} revenus ${yearN} sont composés en partie de revenus considérés comme exceptionnels. En effet, ${p("notre", "mon")} RFR ${yearN} est plus élevé que les années précédentes du fait des cessions de ${introPhrases} intervenues en ${yearN}.
+${p("Sauf erreur de notre part", "Sauf erreur de ma part")}, le mécanisme de quotient prévu à l'article 223 sexies II du Code général des impôts n'a pas été appliqué, alors que les conditions chiffrées d'application ressortent des revenus fiscaux de référence des trois années concernées.
 
-Veuillez noter qu'en ${yearN}, ${p("nos", "mes")} revenus comportaient une part significative de revenus issus des cessions de valeurs mobilières (${introPhrases}) qui ont fortement impacté ${p("notre revenu global", "mon revenu global")} et également ${p("notre", "mon")} revenu fiscal de référence.
+${p("Nous sollicitons", "Je sollicite")} donc le recalcul de la CEHR avec application de ce mécanisme, ainsi que le dégrèvement ou la restitution de la différence correspondante.
 
-Sur ${p("notre", "mon")} avis d'impôt ${yearNp1} sur les revenus ${yearN}, la CEHR a été appliquée sans application du système du quotient et a été calculée comme suit :
+1. RFR concernés et conditions chiffrées du quotient CEHR
 
-Calcul de la CEHR (sans mécanisme du quotient)
-- RFR ${yearN} : ${fmtEur(rfrN)}
-- Base CEHR 3 % : ${fmtEur(c.base3)}
-- Base CEHR 4 % : ${fmtEur(c.base4)}
-- Montant CEHR à 3 % : ${fmtEur(c.amount3)}
-- Montant CEHR à 4 % : ${fmtEur(c.amount4)}
-- Montant CEHR Total : ${fmtEur(c.total)}
-
-${p("Nous remplissons", "Je remplis")} les conditions légales pour bénéficier du quotient. ${p("Nos", "Mes")} trois derniers revenus fiscaux de référence sont les suivants :
+Les revenus fiscaux de référence figurant sur les avis d'imposition concernés sont les suivants :
 
 - RFR ${yearNm2} : ${fmtEur(rfrNm2)}
 - RFR ${yearNm1} : ${fmtEur(rfrNm1)}
 - RFR ${yearN} : ${fmtEur(rfrN)}
 
-Selon ${p("nos", "mes")} estimations, avec application du mécanisme du quotient, le montant de la contribution devrait s'élever à ${fmtEur(quotient.cehrWithQuotient)}.
+La moyenne des RFR ${yearNm2} et ${yearNm1} est donc de ${fmtEur(quotient.averagePrevious)}. Le seuil de comparaison de 1,5 × cette moyenne est de ${fmtEur(threshold150)}.
 
-Ainsi, ${p("nous vous demandons", "je vous demande")}, par la présente, de bien vouloir revoir le calcul de ${p("notre", "mon")} impôt sur les revenus ${yearN} avec notamment le recalcul du montant de la Contribution Exceptionnelle sur les Hauts Revenus avec application du système du quotient.
+Ces montants satisfont les conditions chiffrées suivantes prévues par l'article 223 sexies II du CGI :
 
-Vous trouverez ci-joint l'ensemble des justificatifs relatifs aux cessions ${yearN} :
+- Le RFR ${yearN} dépasse le seuil d'entrée de la CEHR applicable au foyer fiscal : ${fmtEur(rfrN)} > ${fmtEur(quotient.entryThreshold)}.
+- Le RFR ${yearN} est au moins égal à 1,5 fois cette moyenne : ${fmtEur(rfrN)} ≥ ${fmtEur(threshold150)}.
+- Les RFR ${yearNm1} et ${yearNm2} restent chacun inférieurs ou égaux au seuil d'entrée de la CEHR applicable au foyer fiscal : ${fmtEur(rfrNm1)} ≤ ${fmtEur(quotient.entryThreshold)} et ${fmtEur(rfrNm2)} ≤ ${fmtEur(quotient.entryThreshold)}.
+- Les avis d'impôt joints pour les revenus ${yearNm2}, ${yearNm1} et ${yearN} permettent de vérifier la continuité du dossier fiscal sur les trois années concernées.
+
+La hausse du RFR ${yearN} provient notamment de cessions de ${introPhrases} intervenues en ${yearN}, comme indiqué dans les justificatifs joints.
+
+2. Calcul de la CEHR sans quotient
+
+- RFR ${yearN} : ${fmtEur(rfrN)}
+- Base CEHR 3 % : ${fmtEur(c.base3)}
+- Base CEHR 4 % : ${fmtEur(c.base4)}
+- Montant CEHR à 3 % : ${fmtEur(c.amount3)}
+- Montant CEHR à 4 % : ${fmtEur(c.amount4)}
+- Montant total de CEHR : ${fmtEur(c.total)}
+
+3. Calcul de la CEHR avec quotient
+
+- Fraction du RFR ${yearN} au-dessus de cette moyenne : ${fmtEur(rfrN)} - ${fmtEur(quotient.averagePrevious)} = ${fmtEur(excess)}
+- Base lissée retenue pour le quotient : moyenne + moitié de cette fraction, soit ${fmtEur(quotient.averagePrevious)} + (${fmtEur(excess)} / 2) = ${fmtEur(midpoint)}
+- CEHR calculée sur cette base lissée : base à 3 % de ${fmtEur(lissed.base3)} et base à 4 % de ${fmtEur(lissed.base4)}.
+- Montant total de CEHR après quotient : la CEHR calculée sur cette base lissée est doublée, puis le résultat est arrondi à l'euro, soit ${fmtEur(quotient.cehrWithQuotient)}.
+
+La différence entre le calcul sans quotient et le calcul avec quotient est donc estimée à ${fmtEur(quotient.savings)}.
+
+${p("Nous vous remercions", "Je vous remercie")} en conséquence de bien vouloir appliquer le mécanisme de quotient prévu à l'article 223 sexies II du CGI, recalculer la CEHR due au titre des revenus ${yearN}, et procéder au dégrèvement ou à la restitution du trop-versé.
+
+Pièces jointes proposées :
 
 ${[...assetJustificatifs, `Avis d'imposition des revenus ${yearNm2}, ${yearNm1} et ${yearN}`].map((j, i) => `${i + 1}. ${j}`).join("\n")}
 
-En vous remerciant pour votre réponse, ${p("nous vous prions", "je vous prie")} d'agréer, Madame, Monsieur, ${p("nos", "mes")} sincères salutations.
+${p("Nous restons", "Je reste")} à votre disposition pour tout complément ou tout recalcul à partir des montants exacts retenus dans ${p("notre", "mon")} dossier fiscal.
+
+${p("Nous vous prions", "Je vous prie")} d'agréer, Madame, Monsieur, l'expression de ${p("nos", "mes")} salutations distinguées.
 
 Cordialement,
-${signatureLines.join("\n")}
+${signature}
 `;
 };

--- a/lib/taxes/cehr-template.ts
+++ b/lib/taxes/cehr-template.ts
@@ -1,0 +1,144 @@
+import type { QuotientResult } from "./cehr";
+
+export type AssetType = "rsu" | "espp" | "so";
+
+export interface AssetDefinition {
+  id: AssetType;
+  label: string;
+  // Short phrase used inside the intro sentence after "cessions de"
+  intro: string;
+  // Asset-specific supporting documents
+  justificatifs: string[];
+}
+
+export const ASSET_DEFINITIONS: Record<AssetType, AssetDefinition> = {
+  rsu: {
+    id: "rsu",
+    label: "Actions gratuites (RSU)",
+    intro: "actions gratuites (RSU)",
+    justificatifs: [
+      "Courrier d'attribution des RSU (Grant agreement)",
+      "Confirmations de cession (broker)",
+      "Récapitulatif annuel des opérations RSU",
+      "Attestation employeur ventilant gain d'acquisition et plus-value",
+    ],
+  },
+  espp: {
+    id: "espp",
+    label: "ESPP (Employee Stock Purchase Plan)",
+    intro: "actions acquises via le plan d'achat salarié (ESPP)",
+    justificatifs: [
+      "Bulletins d'attribution / d'achat ESPP",
+      "Confirmations de cession ESPP (broker)",
+      "Récapitulatif annuel ESPP",
+    ],
+  },
+  so: {
+    id: "so",
+    label: "Stock-options",
+    intro: "stock-options",
+    justificatifs: [
+      "Courrier d'attribution des stock-options",
+      "Plan de stock-options (et éventuels fractionnements)",
+      "Confirmations de cession des stock-options",
+      "Détail des opérations : attribution, levée, cession",
+    ],
+  },
+};
+
+interface TemplateInputs {
+  yearN: number;
+  rfrN: number;
+  rfrNm1: number;
+  rfrNm2: number;
+  quotient: QuotientResult;
+  assetTypes: AssetType[];
+  situation: "single" | "couple";
+}
+
+const fmtEur = (n: number): string =>
+  `${Math.round(n).toLocaleString("fr-FR")} €`;
+
+const joinFr = (items: string[]): string => {
+  if (items.length === 0) return "";
+  if (items.length === 1) return items[0];
+  return `${items.slice(0, -1).join(", ")} et ${items[items.length - 1]}`;
+};
+
+export const buildCehrEmail = ({
+  yearN,
+  rfrN,
+  rfrNm1,
+  rfrNm2,
+  quotient,
+  assetTypes,
+  situation,
+}: TemplateInputs): string => {
+  if (assetTypes.length === 0) {
+    throw new Error(
+      "buildCehrEmail requires at least one asset type to be selected.",
+    );
+  }
+  const yearNp1 = yearN + 1;
+  const yearNm1 = yearN - 1;
+  const yearNm2 = yearN - 2;
+  const c = quotient.cehrWithoutQuotient;
+
+  const introPhrases = joinFr(
+    assetTypes.map((t) => ASSET_DEFINITIONS[t].intro),
+  );
+  const assetJustificatifs = Array.from(
+    new Set(assetTypes.flatMap((t) => ASSET_DEFINITIONS[t].justificatifs)),
+  );
+
+  const isCouple = situation === "couple";
+  const p = (we: string, i: string): string => (isCouple ? we : i);
+
+  const signatureLines = isCouple
+    ? [
+        "[Nom(s)]",
+        "Numéro fiscal déclarant 1 : [XX XX XXX XXX XXX]",
+        "Numéro fiscal déclarant 2 : [XX XX XXX XXX XXX]",
+      ]
+    : ["[Nom]", "Numéro fiscal : [XX XX XXX XXX XXX]"];
+
+  return `Objet : Demande de lissage de la Contribution Exceptionnelle sur les Hauts Revenus — application du système du quotient — Revenus ${yearN}
+
+Madame, Monsieur,
+
+${p("Nous revenons", "Je reviens")} vers vous suite à la réception de ${p("notre", "mon")} avis d'imposition des revenus ${yearN} établi en ${yearNp1}.
+
+Compte tenu de ${p("notre", "mon")} revenu fiscal de référence (RFR) ${yearN}, ${p("nous avons", "j'ai")} été soumis${isCouple ? "" : "·e"} à la Contribution Exceptionnelle sur les Hauts Revenus. Cependant, ${p("nos", "mes")} revenus ${yearN} sont composés en partie de revenus considérés comme exceptionnels. En effet, ${p("notre", "mon")} RFR ${yearN} est plus élevé que les années précédentes du fait des cessions de ${introPhrases} intervenues en ${yearN}.
+
+Veuillez noter qu'en ${yearN}, ${p("nos", "mes")} revenus étaient constitués en majorité de revenus issus des cessions de valeurs mobilières (${introPhrases}) qui ont fortement impacté ${p("notre revenu global", "mon revenu global")} et également ${p("notre", "mon")} revenu fiscal de référence.
+
+Sur ${p("notre", "mon")} avis d'impôt ${yearNp1} sur les revenus ${yearN}, la CEHR a été appliquée sans application du système du quotient et a été calculée comme suit :
+
+Calcul de la CEHR (sans mécanisme du quotient)
+- RFR ${yearN} : ${fmtEur(rfrN)}
+- Base CEHR 3 % : ${fmtEur(c.base3)}
+- Base CEHR 4 % : ${fmtEur(c.base4)}
+- Montant CEHR à 3 % : ${fmtEur(c.amount3)}
+- Montant CEHR à 4 % : ${fmtEur(c.amount4)}
+- Montant CEHR Total : ${fmtEur(c.total)}
+
+${p("Nous remplissons", "Je remplis")} les conditions légales pour bénéficier du quotient. ${p("Nos", "Mes")} trois derniers revenus fiscaux de référence sont les suivants :
+
+- RFR ${yearNm2} : ${fmtEur(rfrNm2)}
+- RFR ${yearNm1} : ${fmtEur(rfrNm1)}
+- RFR ${yearN} : ${fmtEur(rfrN)}
+
+Selon ${p("nos", "mes")} estimations, avec application du mécanisme du quotient, le montant de la contribution devrait s'élever à ${fmtEur(quotient.cehrWithQuotient)}.
+
+Ainsi, ${p("nous vous demandons", "je vous demande")}, par la présente, de bien vouloir revoir le calcul de ${p("notre", "mon")} impôt sur les revenus ${yearN} avec notamment le recalcul du montant de la Contribution Exceptionnelle sur les Hauts Revenus avec application du système du quotient.
+
+Vous trouverez ci-joint l'ensemble des justificatifs relatifs aux cessions ${yearN} :
+
+${[...assetJustificatifs, `Avis d'imposition des revenus ${yearNm2}, ${yearNm1} et ${yearN}`].map((j, i) => `${i + 1}. ${j}`).join("\n")}
+
+En vous remerciant pour votre réponse, ${p("nous vous prions", "je vous prie")} d'agréer, Madame, Monsieur, ${p("nos", "mes")} sincères salutations.
+
+Cordialement,
+${signatureLines.join("\n")}
+`;
+};

--- a/lib/taxes/cehr-template.ts
+++ b/lib/taxes/cehr-template.ts
@@ -110,7 +110,7 @@ ${p("Nous revenons", "Je reviens")} vers vous suite à la réception de ${p("not
 
 Compte tenu de ${p("notre", "mon")} revenu fiscal de référence (RFR) ${yearN}, ${p("nous avons", "j'ai")} été soumis${isCouple ? "" : "·e"} à la Contribution Exceptionnelle sur les Hauts Revenus. Cependant, ${p("nos", "mes")} revenus ${yearN} sont composés en partie de revenus considérés comme exceptionnels. En effet, ${p("notre", "mon")} RFR ${yearN} est plus élevé que les années précédentes du fait des cessions de ${introPhrases} intervenues en ${yearN}.
 
-Veuillez noter qu'en ${yearN}, ${p("nos", "mes")} revenus étaient constitués en majorité de revenus issus des cessions de valeurs mobilières (${introPhrases}) qui ont fortement impacté ${p("notre revenu global", "mon revenu global")} et également ${p("notre", "mon")} revenu fiscal de référence.
+Veuillez noter qu'en ${yearN}, ${p("nos", "mes")} revenus comportaient une part significative de revenus issus des cessions de valeurs mobilières (${introPhrases}) qui ont fortement impacté ${p("notre revenu global", "mon revenu global")} et également ${p("notre", "mon")} revenu fiscal de référence.
 
 Sur ${p("notre", "mon")} avis d'impôt ${yearNp1} sur les revenus ${yearN}, la CEHR a été appliquée sans application du système du quotient et a été calculée comme suit :
 

--- a/lib/taxes/cehr-template.ts
+++ b/lib/taxes/cehr-template.ts
@@ -1,4 +1,4 @@
-import type { QuotientResult } from "./cehr";
+import { fmtEur, type QuotientResult } from "./cehr";
 
 export type AssetType = "rsu" | "espp" | "so";
 
@@ -55,9 +55,6 @@ interface TemplateInputs {
   assetTypes: AssetType[];
   situation: "single" | "couple";
 }
-
-const fmtEur = (n: number): string =>
-  `${Math.round(n).toLocaleString("fr-FR")} €`;
 
 const joinFr = (items: string[]): string => {
   if (items.length === 0) return "";

--- a/lib/taxes/cehr.test.ts
+++ b/lib/taxes/cehr.test.ts
@@ -1,227 +1,184 @@
-import { computeCehr, computeQuotient, evaluateFieldStatus } from "./cehr";
+import {
+  computeCehr,
+  computeQuotient,
+  evaluateFieldStatus,
+  type FieldStatus,
+  type FoyerSituation,
+} from "./cehr";
+import { buildCehrEmail } from "./cehr-template";
 
 describe("computeCehr", () => {
-  it("returns zero below the first bracket (couple)", () => {
-    expect(computeCehr(400_000, "couple").total).toBe(0);
-  });
+  it.each([
+    [400_000, "couple", 0],
+    [1_285_760, "couple", 26_430],
+    [600_000, "single", 11_500],
+  ] satisfies Array<[number, FoyerSituation, number]>)(
+    "computes CEHR for %s / %s",
+    (rfr, situation, total) => {
+      expect(computeCehr(rfr, situation).total).toBe(total);
+    },
+  );
 
-  it("applies 3% then 4% for a couple above 1M", () => {
-    // RFR 1,285,760 € → 500k @ 3% = 15,000 ; 285,760 @ 4% = 11,430.4
-    const r = computeCehr(1_285_760, "couple");
-    expect(r.amount3).toBeCloseTo(15_000, 2);
-    expect(r.amount4).toBeCloseTo(11_430.4, 2);
-    // Total is rounded to the nearest euro per BOFiP.
-    expect(r.total).toBe(26_430);
-  });
-
-  it("applies the single brackets", () => {
-    const r = computeCehr(600_000, "single");
-    expect(r.base3).toBe(250_000);
-    expect(r.base4).toBe(100_000);
-    expect(r.total).toBeCloseTo(0.03 * 250_000 + 0.04 * 100_000, 2);
+  it("exposes the single 3% and 4% bases", () => {
+    expect(computeCehr(600_000, "single")).toMatchObject({
+      base3: 250_000,
+      base4: 100_000,
+    });
   });
 });
 
 describe("computeQuotient", () => {
   it("reproduces the 2021 Datadog case (couple)", () => {
-    // RFR N-2 = 116,701 ; RFR N-1 = 249,113 ; RFR N = 1,285,760
     const r = computeQuotient({
       rfrN: 1_285_760,
       rfrNm1: 249_113,
       rfrNm2: 116_701,
       situation: "couple",
     });
+
     expect(r.eligible).toBe(true);
-    expect(r.cehrWithoutQuotient.total).toBeCloseTo(26_430.4, 0);
-    // Administration's accepted result was 14,060 €
-    expect(Math.round(r.cehrWithQuotient)).toBe(14_060);
+    expect(r.cehrWithoutQuotient.total).toBe(26_430);
+    expect(r.cehrWithQuotient).toBe(14_060);
   });
 
-  it("marks the request ineligible when RFR does not exceed 1.5× average", () => {
-    const r = computeQuotient({
-      rfrN: 550_000,
-      rfrNm1: 400_000,
-      rfrNm2: 400_000,
-      situation: "couple",
+  it.each([
+    [550_000, 400_000, 400_000, "couple", 1],
+    [1_500_000, 600_000, 100_000, "couple", 2],
+    [100_000, 50_000, 50_000, "single", 0],
+  ] satisfies Array<[number, number, number, FoyerSituation, number]>)(
+    "rejects ineligible quotient case %#",
+    (rfrN, rfrNm1, rfrNm2, situation, failedCheck) => {
+      const r = computeQuotient({
+        rfrN,
+        rfrNm1,
+        rfrNm2,
+        situation,
+      });
+
+      expect(r.eligible).toBe(false);
+      expect(r.checks[failedCheck].passed).toBe(false);
+      expect(r.cehrWithQuotient).toBe(r.cehrWithoutQuotient.total);
+    },
+  );
+
+  it.each([
+    [1_500_000, 500_000, 100_000, "couple"],
+    [600_000, 0, 0, "single"],
+  ] satisfies Array<[number, number, number, FoyerSituation]>)(
+    "accepts eligible quotient case %#",
+    (rfrN, rfrNm1, rfrNm2, situation) => {
+      expect(
+        computeQuotient({
+          rfrN,
+          rfrNm1,
+          rfrNm2,
+          situation,
+        }).eligible,
+      ).toBe(true);
+    },
+  );
+
+  it("uses raw intermediate CEHR totals before rounding the quotient result", () => {
+    expect(
+      computeQuotient({
+        rfrN: 500_040,
+        rfrNm1: 0,
+        rfrNm2: 0,
+        situation: "single",
+      }).cehrWithQuotient,
+    ).toBe(1);
+  });
+});
+
+describe("evaluateFieldStatus", () => {
+  it.each([
+    ["Nm1", null, null, null, "single", "neutral"],
+    ["Nm1", null, 100_000, null, "single", "passed"],
+    ["Nm1", null, 300_000, null, "single", "failed"],
+    ["Nm2", null, null, 400_000, "couple", "passed"],
+    ["Nm2", null, null, 500_000, "couple", "passed"],
+    ["Nm2", null, null, 600_000, "couple", "failed"],
+    ["N", 800_000, 100_000, null, "single", "neutral"],
+    ["N", 100_000, null, null, "single", "failed"],
+    ["N", 100_000, 50_000, 50_000, "single", "failed"],
+    ["N", 800_000, 100_000, 200_000, "single", "passed"],
+    ["N", 200_000, 100_000, 200_000, "single", "failed"],
+  ] satisfies Array<
+    [
+      "N" | "Nm1" | "Nm2",
+      number | null,
+      number | null,
+      number | null,
+      FoyerSituation,
+      FieldStatus,
+    ]
+  >)(
+    "returns %s status for case %#",
+    (field, rfrN, rfrNm1, rfrNm2, situation, expected) => {
+      expect(
+        evaluateFieldStatus({ rfrN, rfrNm1, rfrNm2, situation, field }),
+      ).toBe(expected);
+    },
+  );
+});
+
+describe("buildCehrEmail", () => {
+  const quotient = computeQuotient({
+    rfrN: 600_000,
+    rfrNm1: 0,
+    rfrNm2: 0,
+    situation: "single",
+  });
+
+  it("includes the numeric conditions and quotient calculation details", () => {
+    const email = buildCehrEmail({
+      yearN: 2025,
+      rfrN: 600_000,
+      rfrNm1: 0,
+      rfrNm2: 0,
+      quotient,
+      assetTypes: ["rsu"],
+      situation: "single",
     });
-    expect(r.eligible).toBe(false);
-    // CEHR>0 check passes (RFR N > 500k entry threshold)
-    expect(r.checks[0].passed).toBe(true);
-    // 1.5× check fails (550k < 1.5×400k = 600k)
-    expect(r.checks[1].passed).toBe(false);
+
+    expect(email).toContain("Réclamation contentieuse");
+    expect(email).toContain("conditions chiffrées");
+    expect(email).not.toContain("conditions d'application sont remplies");
+    expect(email).toContain("La moyenne des RFR 2023 et 2024 est donc de");
+    expect(email).toContain(
+      "Le RFR 2025 est au moins égal à 1,5 fois cette moyenne",
+    );
+    expect(email).toContain("3. Calcul de la CEHR avec quotient");
+    expect(email).toContain("- Base lissée retenue pour le quotient :");
+    expect(email).toContain("- Montant total de CEHR après quotient :");
+    expect(email).not.toContain("(× 2 quotient)");
+    expect(email).toContain(
+      "Les avis d'impôt joints pour les revenus 2023, 2024 et 2025",
+    );
   });
 
-  it("rejects when a previous RFR exceeded the CEHR entry threshold", () => {
-    const r = computeQuotient({
-      rfrN: 1_500_000,
-      rfrNm1: 600_000,
-      rfrNm2: 100_000,
-      situation: "couple",
-    });
-    expect(r.eligible).toBe(false);
-    // N-1 check (index 2) fails: 600k > 500k seuil couple
-    expect(r.checks[2].passed).toBe(false);
-  });
-
-  it("accepts a previous RFR exactly at the CEHR entry threshold", () => {
-    // RFR N-1 = 500k for a couple → CEHR(500k) = 0, still under the bracket.
-    const r = computeQuotient({
+  it("uses plural wording for a couple", () => {
+    const coupleQuotient = computeQuotient({
       rfrN: 1_500_000,
       rfrNm1: 500_000,
       rfrNm2: 100_000,
       situation: "couple",
     });
-    expect(r.eligible).toBe(true);
-  });
-
-  it("stays eligible when both previous RFRs are zero", () => {
-    const r = computeQuotient({
-      rfrN: 600_000,
-      rfrNm1: 0,
-      rfrNm2: 0,
-      situation: "single",
+    const email = buildCehrEmail({
+      yearN: 2025,
+      rfrN: 1_500_000,
+      rfrNm1: 500_000,
+      rfrNm2: 100_000,
+      quotient: coupleQuotient,
+      assetTypes: ["rsu"],
+      situation: "couple",
     });
-    expect(r.eligible).toBe(true);
-  });
 
-  it("rejects when RFR N does not trigger any CEHR liability", () => {
-    // Single: avg = 50k, RFR N = 100k (>= 1.5×avg), N-1 and N-2 < 250k seuil,
-    // but RFR N is below CEHR entry → no CEHR is actually due.
-    const r = computeQuotient({
-      rfrN: 100_000,
-      rfrNm1: 50_000,
-      rfrNm2: 50_000,
-      situation: "single",
-    });
-    expect(r.cehrWithoutQuotient.total).toBe(0);
-    expect(r.eligible).toBe(false);
-    expect(r.checks[0].passed).toBe(false);
-  });
-});
-
-describe("evaluateFieldStatus", () => {
-  const base = { rfrN: null, rfrNm1: null, rfrNm2: null } as const;
-
-  it("returns neutral when the targeted field is empty", () => {
-    expect(
-      evaluateFieldStatus({
-        ...base,
-        situation: "single",
-        field: "Nm1",
-      }),
-    ).toBe("neutral");
-    expect(
-      evaluateFieldStatus({
-        ...base,
-        situation: "single",
-        field: "Nm2",
-      }),
-    ).toBe("neutral");
-  });
-
-  it("validates RFR N-1 independently of the others (single)", () => {
-    expect(
-      evaluateFieldStatus({
-        rfrN: null,
-        rfrNm1: 100_000,
-        rfrNm2: null,
-        situation: "single",
-        field: "Nm1",
-      }),
-    ).toBe("passed");
-    expect(
-      evaluateFieldStatus({
-        rfrN: null,
-        rfrNm1: 300_000,
-        rfrNm2: null,
-        situation: "single",
-        field: "Nm1",
-      }),
-    ).toBe("failed");
-  });
-
-  it("validates RFR N-2 independently of the others (couple)", () => {
-    expect(
-      evaluateFieldStatus({
-        rfrN: null,
-        rfrNm1: null,
-        rfrNm2: 400_000,
-        situation: "couple",
-        field: "Nm2",
-      }),
-    ).toBe("passed");
-    expect(
-      evaluateFieldStatus({
-        rfrN: null,
-        rfrNm1: null,
-        rfrNm2: 500_000,
-        situation: "couple",
-        field: "Nm2",
-      }),
-    ).toBe("passed"); // boundary: exactly at threshold → no CEHR due
-    expect(
-      evaluateFieldStatus({
-        rfrN: null,
-        rfrNm1: null,
-        rfrNm2: 600_000,
-        situation: "couple",
-        field: "Nm2",
-      }),
-    ).toBe("failed");
-  });
-
-  it("keeps RFR N neutral until both previous RFRs are filled", () => {
-    expect(
-      evaluateFieldStatus({
-        rfrN: 800_000,
-        rfrNm1: 100_000,
-        rfrNm2: null,
-        situation: "single",
-        field: "N",
-      }),
-    ).toBe("neutral");
-  });
-
-  it("fails RFR N immediately when it is below the CEHR threshold", () => {
-    // single, RFR N = 100k < 250k entry → no CEHR is due, fail early
-    expect(
-      evaluateFieldStatus({
-        rfrN: 100_000,
-        rfrNm1: null,
-        rfrNm2: null,
-        situation: "single",
-        field: "N",
-      }),
-    ).toBe("failed");
-    expect(
-      evaluateFieldStatus({
-        rfrN: 100_000,
-        rfrNm1: 50_000,
-        rfrNm2: 50_000,
-        situation: "single",
-        field: "N",
-      }),
-    ).toBe("failed");
-  });
-
-  it("validates RFR N once both previous RFRs are known", () => {
-    expect(
-      evaluateFieldStatus({
-        rfrN: 800_000,
-        rfrNm1: 100_000,
-        rfrNm2: 200_000,
-        situation: "single",
-        field: "N",
-      }),
-    ).toBe("passed");
-    expect(
-      evaluateFieldStatus({
-        rfrN: 200_000,
-        rfrNm1: 100_000,
-        rfrNm2: 200_000,
-        situation: "single",
-        field: "N",
-      }),
-    ).toBe("failed");
+    expect(email).toContain("Nous vous adressons");
+    expect(email).toContain("Sauf erreur de notre part");
+    expect(email).toContain("Nous sollicitons");
+    expect(email).toContain("notre dossier fiscal");
+    expect(email).toContain("nos salutations distinguées");
+    expect(email).not.toContain("Je vous adresse");
   });
 });

--- a/lib/taxes/cehr.test.ts
+++ b/lib/taxes/cehr.test.ts
@@ -1,0 +1,226 @@
+import { computeCehr, computeQuotient, evaluateFieldStatus } from "./cehr";
+
+describe("computeCehr", () => {
+  it("returns zero below the first bracket (couple)", () => {
+    expect(computeCehr(400_000, "couple").total).toBe(0);
+  });
+
+  it("applies 3% then 4% for a couple above 1M", () => {
+    // RFR 1,285,760 € → 500k @ 3% = 15,000 ; 285,760 @ 4% = 11,430.4
+    const r = computeCehr(1_285_760, "couple");
+    expect(r.amount3).toBeCloseTo(15_000, 2);
+    expect(r.amount4).toBeCloseTo(11_430.4, 2);
+    expect(r.total).toBeCloseTo(26_430.4, 2);
+  });
+
+  it("applies the single brackets", () => {
+    const r = computeCehr(600_000, "single");
+    expect(r.base3).toBe(250_000);
+    expect(r.base4).toBe(100_000);
+    expect(r.total).toBeCloseTo(0.03 * 250_000 + 0.04 * 100_000, 2);
+  });
+});
+
+describe("computeQuotient", () => {
+  it("reproduces the 2021 Datadog case (couple)", () => {
+    // RFR N-2 = 116,701 ; RFR N-1 = 249,113 ; RFR N = 1,285,760
+    const r = computeQuotient({
+      rfrN: 1_285_760,
+      rfrNm1: 249_113,
+      rfrNm2: 116_701,
+      situation: "couple",
+    });
+    expect(r.eligible).toBe(true);
+    expect(r.cehrWithoutQuotient.total).toBeCloseTo(26_430.4, 0);
+    // Administration's accepted result was 14,060 €
+    expect(Math.round(r.cehrWithQuotient)).toBe(14_060);
+  });
+
+  it("marks the request ineligible when RFR does not exceed 1.5× average", () => {
+    const r = computeQuotient({
+      rfrN: 550_000,
+      rfrNm1: 400_000,
+      rfrNm2: 400_000,
+      situation: "couple",
+    });
+    expect(r.eligible).toBe(false);
+    // CEHR>0 check passes (RFR N > 500k entry threshold)
+    expect(r.checks[0].passed).toBe(true);
+    // 1.5× check fails (550k < 1.5×400k = 600k)
+    expect(r.checks[1].passed).toBe(false);
+  });
+
+  it("rejects when a previous RFR exceeded the CEHR entry threshold", () => {
+    const r = computeQuotient({
+      rfrN: 1_500_000,
+      rfrNm1: 600_000,
+      rfrNm2: 100_000,
+      situation: "couple",
+    });
+    expect(r.eligible).toBe(false);
+    // N-1 check (index 2) fails: 600k > 500k seuil couple
+    expect(r.checks[2].passed).toBe(false);
+  });
+
+  it("accepts a previous RFR exactly at the CEHR entry threshold", () => {
+    // RFR N-1 = 500k for a couple → CEHR(500k) = 0, still under the bracket.
+    const r = computeQuotient({
+      rfrN: 1_500_000,
+      rfrNm1: 500_000,
+      rfrNm2: 100_000,
+      situation: "couple",
+    });
+    expect(r.eligible).toBe(true);
+  });
+
+  it("stays eligible when both previous RFRs are zero", () => {
+    const r = computeQuotient({
+      rfrN: 600_000,
+      rfrNm1: 0,
+      rfrNm2: 0,
+      situation: "single",
+    });
+    expect(r.eligible).toBe(true);
+  });
+
+  it("rejects when RFR N does not trigger any CEHR liability", () => {
+    // Single: avg = 50k, RFR N = 100k (>= 1.5×avg), N-1 and N-2 < 250k seuil,
+    // but RFR N is below CEHR entry → no CEHR is actually due.
+    const r = computeQuotient({
+      rfrN: 100_000,
+      rfrNm1: 50_000,
+      rfrNm2: 50_000,
+      situation: "single",
+    });
+    expect(r.cehrWithoutQuotient.total).toBe(0);
+    expect(r.eligible).toBe(false);
+    expect(r.checks[0].passed).toBe(false);
+  });
+});
+
+describe("evaluateFieldStatus", () => {
+  const base = { rfrN: null, rfrNm1: null, rfrNm2: null } as const;
+
+  it("returns neutral when the targeted field is empty", () => {
+    expect(
+      evaluateFieldStatus({
+        ...base,
+        situation: "single",
+        field: "Nm1",
+      }),
+    ).toBe("neutral");
+    expect(
+      evaluateFieldStatus({
+        ...base,
+        situation: "single",
+        field: "Nm2",
+      }),
+    ).toBe("neutral");
+  });
+
+  it("validates RFR N-1 independently of the others (single)", () => {
+    expect(
+      evaluateFieldStatus({
+        rfrN: null,
+        rfrNm1: 100_000,
+        rfrNm2: null,
+        situation: "single",
+        field: "Nm1",
+      }),
+    ).toBe("passed");
+    expect(
+      evaluateFieldStatus({
+        rfrN: null,
+        rfrNm1: 300_000,
+        rfrNm2: null,
+        situation: "single",
+        field: "Nm1",
+      }),
+    ).toBe("failed");
+  });
+
+  it("validates RFR N-2 independently of the others (couple)", () => {
+    expect(
+      evaluateFieldStatus({
+        rfrN: null,
+        rfrNm1: null,
+        rfrNm2: 400_000,
+        situation: "couple",
+        field: "Nm2",
+      }),
+    ).toBe("passed");
+    expect(
+      evaluateFieldStatus({
+        rfrN: null,
+        rfrNm1: null,
+        rfrNm2: 500_000,
+        situation: "couple",
+        field: "Nm2",
+      }),
+    ).toBe("passed"); // boundary: exactly at threshold → no CEHR due
+    expect(
+      evaluateFieldStatus({
+        rfrN: null,
+        rfrNm1: null,
+        rfrNm2: 600_000,
+        situation: "couple",
+        field: "Nm2",
+      }),
+    ).toBe("failed");
+  });
+
+  it("keeps RFR N neutral until both previous RFRs are filled", () => {
+    expect(
+      evaluateFieldStatus({
+        rfrN: 800_000,
+        rfrNm1: 100_000,
+        rfrNm2: null,
+        situation: "single",
+        field: "N",
+      }),
+    ).toBe("neutral");
+  });
+
+  it("fails RFR N immediately when it is below the CEHR threshold", () => {
+    // single, RFR N = 100k < 250k entry → no CEHR is due, fail early
+    expect(
+      evaluateFieldStatus({
+        rfrN: 100_000,
+        rfrNm1: null,
+        rfrNm2: null,
+        situation: "single",
+        field: "N",
+      }),
+    ).toBe("failed");
+    expect(
+      evaluateFieldStatus({
+        rfrN: 100_000,
+        rfrNm1: 50_000,
+        rfrNm2: 50_000,
+        situation: "single",
+        field: "N",
+      }),
+    ).toBe("failed");
+  });
+
+  it("validates RFR N once both previous RFRs are known", () => {
+    expect(
+      evaluateFieldStatus({
+        rfrN: 800_000,
+        rfrNm1: 100_000,
+        rfrNm2: 200_000,
+        situation: "single",
+        field: "N",
+      }),
+    ).toBe("passed");
+    expect(
+      evaluateFieldStatus({
+        rfrN: 200_000,
+        rfrNm1: 100_000,
+        rfrNm2: 200_000,
+        situation: "single",
+        field: "N",
+      }),
+    ).toBe("failed");
+  });
+});

--- a/lib/taxes/cehr.test.ts
+++ b/lib/taxes/cehr.test.ts
@@ -10,7 +10,8 @@ describe("computeCehr", () => {
     const r = computeCehr(1_285_760, "couple");
     expect(r.amount3).toBeCloseTo(15_000, 2);
     expect(r.amount4).toBeCloseTo(11_430.4, 2);
-    expect(r.total).toBeCloseTo(26_430.4, 2);
+    // Total is rounded to the nearest euro per BOFiP.
+    expect(r.total).toBe(26_430);
   });
 
   it("applies the single brackets", () => {

--- a/lib/taxes/cehr.ts
+++ b/lib/taxes/cehr.ts
@@ -23,6 +23,10 @@ const BRACKETS: Record<FoyerSituation, CehrBrackets> = {
 export const cehrEntryThreshold = (situation: FoyerSituation): number =>
   BRACKETS[situation].rate3From;
 
+/** Formats a number as a French-locale euro amount rounded to the nearest unit. */
+export const fmtEur = (n: number): string =>
+  `${Math.round(n).toLocaleString("fr-FR")} €`;
+
 export type FieldStatus = "neutral" | "passed" | "failed";
 
 /**
@@ -77,13 +81,15 @@ export const computeCehr = (
   const base4 = Math.max(0, rfr - b.rate4From);
   const amount3 = base3 * 0.03;
   const amount4 = base4 * 0.04;
+  // Per BOFiP: la contribution est arrondie à l'euro le plus proche.
+  const total = Math.round(amount3 + amount4);
   return {
     rfr,
     base3,
     base4,
     amount3,
     amount4,
-    total: amount3 + amount4,
+    total,
   };
 };
 
@@ -113,8 +119,6 @@ export interface QuotientResult {
   savings: number;
 }
 
-const fmt = (n: number): string => `${Math.round(n).toLocaleString("fr-FR")} €`;
-
 export const computeQuotient = ({
   rfrN,
   rfrNm1,
@@ -128,29 +132,29 @@ export const computeQuotient = ({
 
   const checks: EligibilityCheck[] = [
     {
-      label: `RFR N supérieur au seuil d'application de la CEHR (${fmt(
+      label: `RFR N supérieur au seuil d'application de la CEHR (${fmtEur(
         entryThreshold,
       )})`,
-      detail: `RFR N = ${fmt(rfrN)}`,
+      detail: `RFR N = ${fmtEur(rfrN)}`,
       passed: cehrWithoutQuotient.total > 0,
     },
     {
       label: "RFR N ≥ 1,5 × moyenne des RFR N-1 et N-2",
-      detail: `RFR N = ${fmt(rfrN)} vs 1,5 × moyenne = ${fmt(threshold)}`,
+      detail: `RFR N = ${fmtEur(rfrN)} vs 1,5 × moyenne = ${fmtEur(threshold)}`,
       passed: rfrN >= threshold,
     },
     {
-      label: `RFR N-1 sous le seuil d'application de la CEHR (≤ ${fmt(
+      label: `RFR N-1 sous le seuil d'application de la CEHR (≤ ${fmtEur(
         entryThreshold,
       )})`,
-      detail: `RFR N-1 = ${fmt(rfrNm1)}`,
+      detail: `RFR N-1 = ${fmtEur(rfrNm1)}`,
       passed: rfrNm1 <= entryThreshold,
     },
     {
-      label: `RFR N-2 sous le seuil d'application de la CEHR (≤ ${fmt(
+      label: `RFR N-2 sous le seuil d'application de la CEHR (≤ ${fmtEur(
         entryThreshold,
       )})`,
-      detail: `RFR N-2 = ${fmt(rfrNm2)}`,
+      detail: `RFR N-2 = ${fmtEur(rfrNm2)}`,
       passed: rfrNm2 <= entryThreshold,
     },
   ];
@@ -176,7 +180,10 @@ export const computeQuotient = ({
   const midpoint = averagePrevious + delta / 2;
   const cehrOnAverage = computeCehr(averagePrevious, situation).total;
   const cehrOnMidpoint = computeCehr(midpoint, situation).total;
-  const cehrWithQuotient = cehrOnAverage + 2 * (cehrOnMidpoint - cehrOnAverage);
+  // Per BOFiP: la contribution finale est arrondie à l'euro le plus proche.
+  const cehrWithQuotient = Math.round(
+    cehrOnAverage + 2 * (cehrOnMidpoint - cehrOnAverage),
+  );
 
   return {
     eligible: true,
@@ -188,6 +195,6 @@ export const computeQuotient = ({
     cehrWithQuotient,
     cehrOnAverage,
     cehrOnMidpoint,
-    savings: cehrWithoutQuotient.total - cehrWithQuotient,
+    savings: Math.round(cehrWithoutQuotient.total - cehrWithQuotient),
   };
 };

--- a/lib/taxes/cehr.ts
+++ b/lib/taxes/cehr.ts
@@ -1,21 +1,9 @@
-/**
- * Contribution Exceptionnelle sur les Hauts Revenus (CEHR)
- * Article 223 sexies du Code Général des Impôts.
- *
- * Lissage via le système du quotient applicable aux revenus exceptionnels
- * lorsque le RFR de l'année dépasse de plus de 1,5 fois la moyenne des deux
- * années précédentes (article 223 sexies V CGI).
- */
-
 export type FoyerSituation = "single" | "couple";
 
-interface CehrBrackets {
-  rate3From: number;
-  rate3To: number;
-  rate4From: number;
-}
-
-const BRACKETS: Record<FoyerSituation, CehrBrackets> = {
+const BRACKETS: Record<
+  FoyerSituation,
+  { rate3From: number; rate3To: number; rate4From: number }
+> = {
   single: { rate3From: 250_000, rate3To: 500_000, rate4From: 500_000 },
   couple: { rate3From: 500_000, rate3To: 1_000_000, rate4From: 1_000_000 },
 };
@@ -23,44 +11,34 @@ const BRACKETS: Record<FoyerSituation, CehrBrackets> = {
 export const cehrEntryThreshold = (situation: FoyerSituation): number =>
   BRACKETS[situation].rate3From;
 
-/** Formats a number as a French-locale euro amount rounded to the nearest unit. */
 export const fmtEur = (n: number): string =>
   `${Math.round(n).toLocaleString("fr-FR")} €`;
 
 export type FieldStatus = "neutral" | "passed" | "failed";
 
-/**
- * Evaluates the eligibility status of a single RFR input,
- * independently of the other inputs when possible.
- * - RFR N-1 / N-2: only requires their own value (passed if < seuil CEHR).
- * - RFR N: requires the two previous values to compute the 1.5 × average rule.
- */
-export const evaluateFieldStatus = (params: {
+export const evaluateFieldStatus = ({
+  rfrN,
+  rfrNm1,
+  rfrNm2,
+  situation,
+  field,
+}: {
   rfrN: number | null;
   rfrNm1: number | null;
   rfrNm2: number | null;
   situation: FoyerSituation;
   field: "N" | "Nm1" | "Nm2";
 }): FieldStatus => {
-  const { rfrN, rfrNm1, rfrNm2, situation, field } = params;
   const entry = cehrEntryThreshold(situation);
 
-  if (field === "Nm1") {
-    if (rfrNm1 === null) return "neutral";
-    return rfrNm1 <= entry ? "passed" : "failed";
-  }
-  if (field === "Nm2") {
-    if (rfrNm2 === null) return "neutral";
-    return rfrNm2 <= entry ? "passed" : "failed";
-  }
-  // field === "N"
+  if (field === "Nm1")
+    return rfrNm1 === null ? "neutral" : rfrNm1 <= entry ? "passed" : "failed";
+  if (field === "Nm2")
+    return rfrNm2 === null ? "neutral" : rfrNm2 <= entry ? "passed" : "failed";
   if (rfrN === null) return "neutral";
-  // Standalone check: RFR N must exceed the CEHR entry threshold,
-  // otherwise no CEHR is due and the quotient is moot.
   if (rfrN <= entry) return "failed";
   if (rfrNm1 === null || rfrNm2 === null) return "neutral";
-  const avg = (rfrNm1 + rfrNm2) / 2;
-  return rfrN >= 1.5 * avg ? "passed" : "failed";
+  return rfrN >= 1.5 * ((rfrNm1 + rfrNm2) / 2) ? "passed" : "failed";
 };
 
 export interface CehrBreakdown {
@@ -69,6 +47,7 @@ export interface CehrBreakdown {
   base4: number;
   amount3: number;
   amount4: number;
+  rawTotal: number;
   total: number;
 }
 
@@ -81,15 +60,15 @@ export const computeCehr = (
   const base4 = Math.max(0, rfr - b.rate4From);
   const amount3 = base3 * 0.03;
   const amount4 = base4 * 0.04;
-  // Per BOFiP: la contribution est arrondie à l'euro le plus proche.
-  const total = Math.round(amount3 + amount4);
+  const rawTotal = amount3 + amount4;
   return {
     rfr,
     base3,
     base4,
     amount3,
     amount4,
-    total,
+    rawTotal,
+    total: Math.round(rawTotal),
   };
 };
 
@@ -178,9 +157,8 @@ export const computeQuotient = ({
 
   const delta = rfrN - averagePrevious;
   const midpoint = averagePrevious + delta / 2;
-  const cehrOnAverage = computeCehr(averagePrevious, situation).total;
-  const cehrOnMidpoint = computeCehr(midpoint, situation).total;
-  // Per BOFiP: la contribution finale est arrondie à l'euro le plus proche.
+  const cehrOnAverage = computeCehr(averagePrevious, situation).rawTotal;
+  const cehrOnMidpoint = computeCehr(midpoint, situation).rawTotal;
   const cehrWithQuotient = Math.round(
     cehrOnAverage + 2 * (cehrOnMidpoint - cehrOnAverage),
   );

--- a/lib/taxes/cehr.ts
+++ b/lib/taxes/cehr.ts
@@ -1,0 +1,193 @@
+/**
+ * Contribution Exceptionnelle sur les Hauts Revenus (CEHR)
+ * Article 223 sexies du Code Général des Impôts.
+ *
+ * Lissage via le système du quotient applicable aux revenus exceptionnels
+ * lorsque le RFR de l'année dépasse de plus de 1,5 fois la moyenne des deux
+ * années précédentes (article 223 sexies V CGI).
+ */
+
+export type FoyerSituation = "single" | "couple";
+
+interface CehrBrackets {
+  rate3From: number;
+  rate3To: number;
+  rate4From: number;
+}
+
+const BRACKETS: Record<FoyerSituation, CehrBrackets> = {
+  single: { rate3From: 250_000, rate3To: 500_000, rate4From: 500_000 },
+  couple: { rate3From: 500_000, rate3To: 1_000_000, rate4From: 1_000_000 },
+};
+
+export const cehrEntryThreshold = (situation: FoyerSituation): number =>
+  BRACKETS[situation].rate3From;
+
+export type FieldStatus = "neutral" | "passed" | "failed";
+
+/**
+ * Evaluates the eligibility status of a single RFR input,
+ * independently of the other inputs when possible.
+ * - RFR N-1 / N-2: only requires their own value (passed if < seuil CEHR).
+ * - RFR N: requires the two previous values to compute the 1.5 × average rule.
+ */
+export const evaluateFieldStatus = (params: {
+  rfrN: number | null;
+  rfrNm1: number | null;
+  rfrNm2: number | null;
+  situation: FoyerSituation;
+  field: "N" | "Nm1" | "Nm2";
+}): FieldStatus => {
+  const { rfrN, rfrNm1, rfrNm2, situation, field } = params;
+  const entry = cehrEntryThreshold(situation);
+
+  if (field === "Nm1") {
+    if (rfrNm1 === null) return "neutral";
+    return rfrNm1 <= entry ? "passed" : "failed";
+  }
+  if (field === "Nm2") {
+    if (rfrNm2 === null) return "neutral";
+    return rfrNm2 <= entry ? "passed" : "failed";
+  }
+  // field === "N"
+  if (rfrN === null) return "neutral";
+  // Standalone check: RFR N must exceed the CEHR entry threshold,
+  // otherwise no CEHR is due and the quotient is moot.
+  if (rfrN <= entry) return "failed";
+  if (rfrNm1 === null || rfrNm2 === null) return "neutral";
+  const avg = (rfrNm1 + rfrNm2) / 2;
+  return rfrN >= 1.5 * avg ? "passed" : "failed";
+};
+
+export interface CehrBreakdown {
+  rfr: number;
+  base3: number;
+  base4: number;
+  amount3: number;
+  amount4: number;
+  total: number;
+}
+
+export const computeCehr = (
+  rfr: number,
+  situation: FoyerSituation,
+): CehrBreakdown => {
+  const b = BRACKETS[situation];
+  const base3 = Math.max(0, Math.min(rfr, b.rate3To) - b.rate3From);
+  const base4 = Math.max(0, rfr - b.rate4From);
+  const amount3 = base3 * 0.03;
+  const amount4 = base4 * 0.04;
+  return {
+    rfr,
+    base3,
+    base4,
+    amount3,
+    amount4,
+    total: amount3 + amount4,
+  };
+};
+
+export interface QuotientInputs {
+  rfrN: number;
+  rfrNm1: number;
+  rfrNm2: number;
+  situation: FoyerSituation;
+}
+
+export interface EligibilityCheck {
+  label: string;
+  detail: string;
+  passed: boolean;
+}
+
+export interface QuotientResult {
+  eligible: boolean;
+  checks: EligibilityCheck[];
+  averagePrevious: number;
+  threshold: number;
+  entryThreshold: number;
+  cehrWithoutQuotient: CehrBreakdown;
+  cehrWithQuotient: number;
+  cehrOnAverage: number;
+  cehrOnMidpoint: number;
+  savings: number;
+}
+
+const fmt = (n: number): string => `${Math.round(n).toLocaleString("fr-FR")} €`;
+
+export const computeQuotient = ({
+  rfrN,
+  rfrNm1,
+  rfrNm2,
+  situation,
+}: QuotientInputs): QuotientResult => {
+  const averagePrevious = (rfrNm1 + rfrNm2) / 2;
+  const threshold = 1.5 * averagePrevious;
+  const entryThreshold = cehrEntryThreshold(situation);
+  const cehrWithoutQuotient = computeCehr(rfrN, situation);
+
+  const checks: EligibilityCheck[] = [
+    {
+      label: `RFR N supérieur au seuil d'application de la CEHR (${fmt(
+        entryThreshold,
+      )})`,
+      detail: `RFR N = ${fmt(rfrN)}`,
+      passed: cehrWithoutQuotient.total > 0,
+    },
+    {
+      label: "RFR N ≥ 1,5 × moyenne des RFR N-1 et N-2",
+      detail: `RFR N = ${fmt(rfrN)} vs 1,5 × moyenne = ${fmt(threshold)}`,
+      passed: rfrN >= threshold,
+    },
+    {
+      label: `RFR N-1 sous le seuil d'application de la CEHR (≤ ${fmt(
+        entryThreshold,
+      )})`,
+      detail: `RFR N-1 = ${fmt(rfrNm1)}`,
+      passed: rfrNm1 <= entryThreshold,
+    },
+    {
+      label: `RFR N-2 sous le seuil d'application de la CEHR (≤ ${fmt(
+        entryThreshold,
+      )})`,
+      detail: `RFR N-2 = ${fmt(rfrNm2)}`,
+      passed: rfrNm2 <= entryThreshold,
+    },
+  ];
+
+  const eligible = checks.every((c) => c.passed);
+
+  if (!eligible) {
+    return {
+      eligible: false,
+      checks,
+      averagePrevious,
+      threshold,
+      entryThreshold,
+      cehrWithoutQuotient,
+      cehrWithQuotient: cehrWithoutQuotient.total,
+      cehrOnAverage: 0,
+      cehrOnMidpoint: 0,
+      savings: 0,
+    };
+  }
+
+  const delta = rfrN - averagePrevious;
+  const midpoint = averagePrevious + delta / 2;
+  const cehrOnAverage = computeCehr(averagePrevious, situation).total;
+  const cehrOnMidpoint = computeCehr(midpoint, situation).total;
+  const cehrWithQuotient = cehrOnAverage + 2 * (cehrOnMidpoint - cehrOnAverage);
+
+  return {
+    eligible: true,
+    checks,
+    averagePrevious,
+    threshold,
+    entryThreshold,
+    cehrWithoutQuotient,
+    cehrWithQuotient,
+    cehrOnAverage,
+    cehrOnMidpoint,
+    savings: cehrWithoutQuotient.total - cehrWithQuotient,
+  };
+};


### PR DESCRIPTION
## Summary
New `/cehr` page that helps users assess whether they qualify for the smoothing mechanism of the French Contribution Exceptionnelle sur les Hauts Revenus (art. 223 sexies V CGI), see a side-by-side CEHR computation, and generate a ready-to-send reclamation email.

- Eligibility checked per-field (with ✓/✗ feedback) against the 4 cumulative conditions: CEHR liability, 1.5× rule on RFR N, both prior RFRs ≤ entry threshold.
- Side-by-side table comparing CEHR without/with quotient. Expandable inline row shows the 4-step computation of the smoothed base.
- Email template adapts to selected asset types (RSU / ESPP / stock-options) and to the foyer situation (couple → plural with declarant 2, single → singular).
- Explicit disclaimer when the foyer situation changed across the 3 years.

<img width="1762" height="1620" alt="image" src="https://github.com/user-attachments/assets/d84caaa3-82b2-420e-838b-8ce3cea37513" />
<img width="3110" height="910" alt="image (1)" src="https://github.com/user-attachments/assets/84974863-1080-44de-8842-d015f4535d96" />
<img width="3104" height="1950" alt="image (2)" src="https://github.com/user-attachments/assets/592bc462-0118-4af8-9609-733b951a3cff" />

## Test plan
- [x] `yarn jest lib/taxes/cehr.test.ts` — 15/15 green (incl. the real 2021 Datadog case landing exactly on the administration's accepted 14 060 €).
- [x] `yarn lint` clean
- [x] `yarn build` succeeds
- [x] Manual smoke (headless screenshots): empty state, error when RFR N below CEHR threshold, error when prior RFR above threshold, happy path on the prosper-conseil canonical example (200/100/800 k€ single → 19 500 € → 13 500 €, gain 6 000 €), expandable base-lissée row.

## Codex review iterations
Asked Codex to review the diff iteratively; addressed: (a) eligible-when-no-CEHR-due, (b) NaN propagation after clearing inputs, (c) silent RSU fallback on empty asset selection, (d) declarant 2 leaking into single signature, (e) ≤ vs < at the entry threshold, (f) hidden CEHR-threshold failure on the N field, (g) help-text wording aligned to ≤, (h) intro no longer mentions unsupported revenue types (prime, indemnité), (i) email wording softened from "en majorité" to "une part significative".