### PR TITLE
fix: support ETrade 2025 "Qualified Plan?" column name

### DIFF
--- a/lib/etrade/etrade.types.ts
+++ b/lib/etrade/etrade.types.ts
@@ -27,7 +27,7 @@ export interface GainAndLossEventXlsxRow2025 {
   "Acquisition Cost Per Share": number;
   "Purchase Date Fair Mkt. Value": string | number;
   "Proceeds Per Share": number;
-  "Qualified Plan": PlanQualification;
+  "Qualified Plan?": PlanQualification;
   "Grant Date": string;
 }
 

--- a/lib/etrade/parse-etrade-gl.ts
+++ b/lib/etrade/parse-etrade-gl.ts
@@ -43,7 +43,9 @@ const parseEtradeGLRow = (row: GainAndLossEventXlsxRow): GainAndLossEvent => {
   );
   // For now consider that a non-US qualified plan is FR qualified.
   // FIXME: this is actually wrong, ETrade doesn't fill in the "Qualified Plan" column for qualified RSU plans.
-  const qualifiedIn = row["Qualified Plan"] === "Qualified" ? "us" : "fr";
+  const qualifiedIn =
+    ("Qualified Plan" in row ? row["Qualified Plan"] : row["Qualified Plan?"])
+    === "Qualified" ? "us" : "fr";
 
   // Make sure each row is valid
   return {


### PR DESCRIPTION
## Summary

ETrade renamed the `"Qualified Plan"` column to `"Qualified Plan?"` in the 2025 Gain/Loss export format.

- Update `GainAndLossEventXlsxRow2025` type to use `"Qualified Plan?"`
- Accept both `"Qualified Plan"` and `"Qualified Plan?"` in the parser so pre-2025 and 2025 files both work

## Test plan

- [ ] Upload a pre-2025 G&L file — qualification column is parsed correctly
- [ ] Upload a 2025 G&L file — no crash on the `"Qualified Plan?"` column