### PR TITLE
fix: handle ECB non-trading days and propagate fetch errors

### DIFF
--- a/app/api/euro/[date]/route.ts
+++ b/app/api/euro/[date]/route.ts
@@ -13,36 +13,49 @@ interface DataSet {
   validFrom: string;
   series: Series;
 }
-interface Response {
+interface EcbResponse {
   dataSets: DataSet[];
 }
 
-const baseFetchExchangeRate = async (date: string): Promise<number> => {
+const dayBefore = (date: string): string => {
+  const [year, month, day] = date.split("-").map(Number);
+  const d = new Date(Date.UTC(year, month - 1, day));
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().substring(0, 10);
+};
+
+const baseFetchExchangeRate = async (
+  date: string,
+  retriesLeft = 5,
+): Promise<number> => {
   const url = new URL(API_BASE_URL);
   url.searchParams.set("format", "jsondata");
   url.searchParams.set("detail", "dataonly");
   url.searchParams.set("startPeriod", date);
   url.searchParams.set("endPeriod", date);
 
-  // Fetch the exchange rate, with no cache to avoid having staled data
-  return fetch(url, { cache: "no-cache" })
-    .then((res) => {
-      try {
-        return res.json();
-      } catch (error) {
-        // Transform the error into a more user-friendly one
-        throw new Error(
-          `${(error as Error).message} for ${date}
-Response status: ${res.statusText} ${res.statusText}
-Response body:
-${res.text()}`,
-        );
-      }
-    })
-    .then(
-      (data: Response) =>
-        data.dataSets[0].series["0:0:0:0:0"].observations[0][0],
-    );
+  const res = await fetch(url, { cache: "no-cache" });
+  const text = await res.text();
+  let observations: EcbResponse["dataSets"][0]["series"]["0:0:0:0:0"]["observations"] | undefined;
+  try {
+    const data: EcbResponse = JSON.parse(text);
+    observations = data.dataSets?.[0]?.series?.["0:0:0:0:0"]?.observations;
+  } catch {
+    // ECB returns empty body (not JSON) when no data exists for the date — treat as no data
+  }
+
+  if (!observations?.["0"]) {
+    // ECB publishes no rate for this date (e.g. Good Friday or other ECB-specific closure).
+    // Fall back to the previous calendar day.
+    if (retriesLeft <= 0) {
+      throw new Error(
+        `No ECB exchange rate found for ${date} or any of the 5 preceding days`,
+      );
+    }
+    return baseFetchExchangeRate(dayBefore(date), retriesLeft - 1);
+  }
+
+  return observations["0"][0];
 };
 
 /**

--- a/hooks/use-fetch-exr.ts
+++ b/hooks/use-fetch-exr.ts
@@ -7,11 +7,11 @@ import { dayBefore, isWeekend } from "@/lib/date";
 const apiUrl = "/api/euro/{date}";
 
 const fetchExchangeRate = async (date: string): Promise<number> => {
-  return fetch(`${apiUrl.replace("{date}", date)}`)
-    .then((res) => res.json())
-    .then((response: number) => {
-      return response;
-    });
+  const res = await fetch(`${apiUrl.replace("{date}", date)}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch exchange rate for ${date}: HTTP ${res.status}`);
+  }
+  return res.json();
 };
 
 interface UseExchangeRateResponse {


### PR DESCRIPTION
## Summary

The ECB API returns **HTTP 200 with an empty body** for non-trading days (e.g. Good Friday, Easter Monday). The previous code called `res.json()` directly, which threw `"Unexpected end of JSON input"` → 500 → frontend crash.

Changes:
- **`app/api/euro/[date]/route.ts`**: read response as text, try `JSON.parse` in a try/catch, and fall back to the previous calendar day (up to 5 retries) when no rate is available. Also rename the local `Response` interface to `EcbResponse` to avoid shadowing the global `Response` type.
- **`hooks/use-fetch-exr.ts`**: check `res.ok` before parsing JSON so HTTP errors are properly surfaced as react-query errors instead of being silently treated as a valid rate.

## Test plan

- [ ] Upload a G&L file with an acquisition date that falls on Good Friday — rate is fetched from the previous trading day without error
- [ ] Confirm a date with no rate available within 5 days throws a clear error message